### PR TITLE
Cover the decomposition, steering, and atlas paths left untested by #217

### DIFF
--- a/tests/odyssey/data/test_move_to_device.py
+++ b/tests/odyssey/data/test_move_to_device.py
@@ -1,0 +1,33 @@
+"""move_to_device walks nested NamedTuples without knowing their fields."""
+
+from typing import NamedTuple
+
+import torch
+
+from odyssey.data.streaming import move_to_device
+
+
+class _Inner(NamedTuple):
+    x: torch.Tensor
+    label: str
+
+
+class _Outer(NamedTuple):
+    inner: _Inner
+    y: torch.Tensor
+    n: int
+
+
+def test_moves_every_tensor_and_keeps_structure_and_non_tensors() -> None:
+    outer = _Outer(_Inner(torch.ones(2), "keep"), torch.zeros(3), 7)
+    moved = move_to_device(outer, "cpu")
+    assert isinstance(moved, _Outer) and isinstance(moved.inner, _Inner)
+    assert torch.equal(moved.inner.x, outer.inner.x)
+    assert moved.inner.label == "keep" and moved.n == 7
+    assert moved.y.device.type == "cpu"
+
+
+def test_bare_tensor_and_plain_values_pass_through() -> None:
+    assert torch.equal(move_to_device(torch.arange(3), "cpu"), torch.arange(3))
+    assert move_to_device("untouched", "cpu") == "untouched"
+    assert move_to_device((1, 2), "cpu") == (1, 2)  # a plain tuple is not a NamedTuple

--- a/tests/odyssey/inference/test_steering_pass.py
+++ b/tests/odyssey/inference/test_steering_pass.py
@@ -1,0 +1,261 @@
+"""The steering pass and its orchestration on a tiny in-memory model.
+
+``prepare`` and the CLI need a saved run and are exercised in
+tests/odyssey/training/test_train_steering.py; here everything after
+loading is driven directly so each piece is checked on known inputs.
+"""
+
+from datetime import datetime, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+import torch
+from torch import nn
+
+from odyssey.data.concepts import concepts_for_source
+from odyssey.data.vocabulary import Vocabulary
+from odyssey.inference.steering import (
+    CLINICAL_EXPECTATIONS,
+    HORIZONS_HOURS,
+    SteeringPrepared,
+    SteeringPush,
+    SubjectReadout,
+    _labels_for,
+    _outcome_risk,
+    _to_json,
+    clinician_line,
+    evaluate_steering,
+    run_steering_pass,
+)
+from odyssey.models.backbones.tiny_gru import TinyGRUBackbone
+from odyssey.models.sequence_model import ConceptBottleneckSequenceModel
+from odyssey.models.steering import steering_direction, steering_gamma
+
+
+T0 = datetime(2024, 1, 1)
+CODES = [f"LAB//{i}//" for i in range(8)]
+EVENTS = ["death", "icu_admission"]
+NAMES = ["tachycardia", "hypotension", "fever"]
+
+
+def _vocab() -> Vocabulary:
+    tokens = {"[PAD]": 0, "[UNK]": 1}
+    tokens.update({c: i + 2 for i, c in enumerate(CODES)})
+    return Vocabulary(tokens)
+
+
+def _events() -> pl.DataFrame:
+    rows = [
+        (sid, CODES[(sid + i) % len(CODES)], T0 + timedelta(hours=i), None, 100 + sid)
+        for sid in (1, 2, 3, 4)
+        for i in range(10)
+    ]
+    return pl.DataFrame(
+        rows,
+        schema={
+            "subject_id": pl.Int64,
+            "code": pl.Utf8,
+            "time": pl.Datetime,
+            "numeric_value": pl.Float32,
+            "hadm_id": pl.Int64,
+        },
+        orient="row",
+    )
+
+
+def _model(vocab_size: int, with_heads: bool = True) -> ConceptBottleneckSequenceModel:
+    torch.manual_seed(0)
+    model = ConceptBottleneckSequenceModel(
+        backbone=TinyGRUBackbone(vocab_size=vocab_size, hidden_size=8, padding_idx=0),
+        vocab_size=vocab_size,
+        num_concepts=len(NAMES),
+        embedding_dim=4,
+        padding_idx=0,
+        bottleneck_kind="decomposed",
+        event_names=EVENTS if with_heads else None,
+    )
+    # The tiny GRU has no block list; give the stream site a block to hook.
+    model.backbone.layers = nn.ModuleList([nn.Identity()])  # type: ignore[attr-defined]
+    model.eval()
+    return model
+
+
+def _prepared(
+    model: ConceptBottleneckSequenceModel, vocab: Vocabulary
+) -> SteeringPrepared:
+    lifted = {0: [2, 3], 1: [4], 2: []}
+    return SteeringPrepared(
+        model=model,
+        vocab=vocab,
+        events_binned=_events(),
+        concept_names=NAMES,
+        event_names=EVENTS,
+        lifted=lifted,
+        gammas=[
+            steering_gamma(model, steering_direction(model, c), tau=1.0)
+            for c in range(3)
+        ],
+        supervision="stay",
+        tables=None,
+        token_names={},
+    )
+
+
+def test_pass_visits_every_subject_once_and_reads_at_risk_everywhere_without_tables() -> (
+    None
+):
+    vocab = _vocab()
+    model = _model(len(vocab.token_to_id))
+    lifted = [torch.tensor([2, 3]), torch.tensor([], dtype=torch.long)]
+    readouts = run_steering_pass(
+        model,
+        _events(),
+        vocab,
+        push=None,
+        lifted_sets=lifted,
+        tables=None,
+        num_lanes=2,
+        chunk_size=8,
+        device="cpu",
+    )
+    assert set(readouts) == {1, 2, 3, 4}
+    r = readouts[1]
+    assert r.n == 9  # ten events, nine next-event positions
+    assert r.risk_means().shape == (len(EVENTS), len(HORIZONS_HOURS))
+    assert not np.isnan(r.risk_means()).any()  # every position counts as at risk
+    mass = r.lifted_mass / r.n
+    assert 0.0 < mass[0] < 1.0
+    assert mass[1] == 0.0  # empty lifted set contributes no mass
+
+
+@pytest.mark.parametrize("site", ["bottleneck", "stream"])
+def test_pushed_pass_changes_the_readout_and_keeps_the_subjects(site: str) -> None:
+    vocab = _vocab()
+    model = _model(len(vocab.token_to_id))
+    lifted = [torch.tensor([2, 3])]
+    base = run_steering_pass(
+        model,
+        _events(),
+        vocab,
+        push=None,
+        lifted_sets=lifted,
+        tables=None,
+        num_lanes=2,
+        chunk_size=8,
+        device="cpu",
+    )
+    push = SteeringPush(concept_index=0, gamma=2.0, site=site, layer_index=0)
+    steered = run_steering_pass(
+        model,
+        _events(),
+        vocab,
+        push=push,
+        lifted_sets=lifted,
+        tables=None,
+        num_lanes=2,
+        chunk_size=8,
+        device="cpu",
+    )
+    assert set(steered) == set(base)
+    if site == "bottleneck":
+        # the bottleneck sum moves by gamma e_c, so the hazard heads see
+        # different features and the risks move
+        assert not np.allclose(steered[1].risk_means(), base[1].risk_means())
+    else:
+        # the identity block's hook adds the vector after the GRU; the
+        # plumbing ran and produced finite readouts
+        assert np.isfinite(steered[1].risk_means()).all()
+
+
+def test_outcome_risk_needs_hazard_heads() -> None:
+    vocab = _vocab()
+    with pytest.raises(ValueError, match="hazard heads"):
+        _outcome_risk(
+            _model(len(vocab.token_to_id), with_heads=False), torch.zeros(2, 8)
+        )
+
+
+def test_readout_accumulates_across_chunks() -> None:
+    r = SubjectReadout()
+    probs = torch.tensor([[0.2, 0.8]])
+    mass = torch.tensor([[0.5]])
+    risk = torch.tensor([[[0.1, 0.2, 0.3]]])
+    at_risk = torch.tensor([[True]])
+    r.add(probs, mass, risk, at_risk)
+    r.add(probs, mass, risk, torch.tensor([[False]]))
+    assert r.n == 2
+    assert r.risk_n.tolist() == [1.0]
+    assert np.allclose(r.risk_means(), [[0.1, 0.2, 0.3]])
+    assert np.allclose(r.concept_probs / r.n, [0.2, 0.8])
+
+
+def test_evaluate_steering_runs_every_expected_dial_both_ways_and_serializes() -> None:
+    vocab = _vocab()
+    model = _model(len(vocab.token_to_id))
+    prepared = _prepared(model, vocab)
+    summaries = evaluate_steering(
+        prepared,
+        concepts=None,
+        site="bottleneck",
+        layer_index=None,
+        suppress_strength=None,
+        num_lanes=2,
+        chunk_size=8,
+        device="cpu",
+        n_boot=20,
+    )
+    expected = [n for n in NAMES if n in CLINICAL_EXPECTATIONS]
+    assert [s.concept for s in summaries] == [n for n in expected for _ in range(2)]
+    assert [s.direction for s in summaries[:2]] == ["amplify", "suppress"]
+    assert summaries[0].gamma > 0 > summaries[1].gamma
+    assert summaries[0].n_subjects == 4
+    for s in summaries:
+        assert len(s.outcomes) == len(EVENTS) * len(HORIZONS_HOURS)
+        assert "k_c" in clinician_line(s)
+    payload = _to_json(summaries)
+    assert len(payload) == len(summaries)
+    first = payload[0]
+    assert {"concept", "direction", "gamma", "outcomes", "sign_agreement"} <= set(first)
+    assert {"relative_change", "as_expected", "separated"} <= set(first["outcomes"][0])
+
+
+def test_evaluate_steering_rejects_unknown_concepts_and_honours_a_selection() -> None:
+    vocab = _vocab()
+    model = _model(len(vocab.token_to_id))
+    prepared = _prepared(model, vocab)
+    with pytest.raises(ValueError, match="not in this run's registry"):
+        evaluate_steering(
+            prepared,
+            concepts=["sepsis3"],
+            site="bottleneck",
+            layer_index=None,
+            suppress_strength=None,
+            num_lanes=2,
+            chunk_size=8,
+            device="cpu",
+            n_boot=10,
+        )
+    summaries = evaluate_steering(
+        prepared,
+        concepts=["fever"],
+        site="stream",
+        layer_index=0,
+        suppress_strength=0.3,
+        num_lanes=2,
+        chunk_size=8,
+        device="cpu",
+        n_boot=10,
+    )
+    assert [s.concept for s in summaries] == ["fever", "fever"]
+    assert summaries[0].site == "stream"
+
+
+def test_labels_for_builds_stay_and_visit_dictionaries() -> None:
+    concepts = concepts_for_source("mimic_iv", task_set="v1")
+    raw = _events()
+    for supervision in ("stay", "visit"):
+        labels, mask, first = _labels_for(raw, concepts, supervision)
+        assert len(labels) == len(mask) == len(first)
+        row = next(iter(labels.values()))
+        assert row.shape[-1] == len(concepts)

--- a/tests/odyssey/models/test_decomposed_edge_cases.py
+++ b/tests/odyssey/models/test_decomposed_edge_cases.py
@@ -1,0 +1,47 @@
+"""Guard rails and degenerate inputs of the decomposed bottleneck."""
+
+import pytest
+import torch
+
+from odyssey.models.concept_bottleneck import (
+    ConceptBottleneck,
+    DecomposedConceptBottleneck,
+    independence_loss,
+    reconstruction_loss,
+)
+
+
+def test_constructors_reject_non_positive_sizes() -> None:
+    with pytest.raises(ValueError, match="num_concepts"):
+        DecomposedConceptBottleneck(hidden_size=8, num_concepts=0)
+    with pytest.raises(ValueError, match="unknown_ratio"):
+        DecomposedConceptBottleneck(hidden_size=8, num_concepts=2, unknown_ratio=0)
+    with pytest.raises(ValueError, match="unknown_dim"):
+        ConceptBottleneck(hidden_size=8, num_concepts=2, embedding_dim=4, unknown_dim=0)
+
+
+def test_reconstruction_loss_is_zero_when_no_position_is_labeled() -> None:
+    hidden = torch.randn(2, 3, 8)
+    unknown = torch.randn(2, 3, 8, requires_grad=True)
+    known = torch.randn(2, 8)
+    labels = torch.zeros(2, 3, 2)
+    mask = torch.zeros(2, 3, 2, dtype=torch.bool)
+    loss = reconstruction_loss(unknown, hidden, known, labels, concept_mask=mask)
+    assert loss.item() == 0.0 and loss.shape == ()
+
+
+def test_independence_loss_needs_two_positions() -> None:
+    known = torch.randn(1, 1, 8)
+    unknown = torch.randn(1, 1, 8)
+    assert independence_loss(known, unknown).item() == 0.0
+    # with a mask that keeps one position of several the same guard applies
+    known = torch.randn(1, 4, 8)
+    unknown = torch.randn(1, 4, 8)
+    keep = torch.tensor([[True, False, False, False]])
+    assert independence_loss(known, unknown, keep).item() == 0.0
+    assert independence_loss(known, unknown).item() >= 0.0
+
+
+def test_decomposed_bottleneck_declines_the_orthogonality_fold_in() -> None:
+    bottleneck = DecomposedConceptBottleneck(hidden_size=8, num_concepts=2)
+    assert bottleneck.unaccounted_orthogonality().item() == 0.0

--- a/tests/odyssey/models/test_steering_definitions.py
+++ b/tests/odyssey/models/test_steering_definitions.py
@@ -1,0 +1,68 @@
+"""Edge cases of the steering definitions and the layer-injection hook."""
+
+import pytest
+import torch
+from torch import nn
+
+from odyssey.models.backbones.tiny_gru import TinyGRUBackbone
+from odyssey.models.injection import middle_layer, stream_injection
+from odyssey.models.sequence_model import ConceptBottleneckSequenceModel
+from odyssey.models.steering import steering_direction, steering_gamma
+
+
+def _model(kind: str) -> ConceptBottleneckSequenceModel:
+    torch.manual_seed(0)
+    return ConceptBottleneckSequenceModel(
+        backbone=TinyGRUBackbone(vocab_size=9, hidden_size=8, padding_idx=0),
+        vocab_size=9,
+        num_concepts=2,
+        embedding_dim=4,
+        padding_idx=0,
+        bottleneck_kind=kind,
+    )
+
+
+class _TupleBlock(nn.Module):
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, str]:  # noqa: D102
+        return x, "cache"
+
+
+class _Backbone(nn.Module):
+    def __init__(self, n: int) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList([_TupleBlock() for _ in range(n)])
+
+
+def test_injection_pushes_the_hidden_state_of_a_tuple_returning_block() -> None:
+    backbone = _Backbone(3)
+    x = torch.zeros(2, 4)
+    vec = torch.ones(4)
+    with stream_injection(backbone, 2, vec):
+        hidden, rest = backbone.layers[2](x)
+    assert torch.equal(hidden, torch.ones(2, 4))
+    assert rest == "cache"
+    hidden, _ = backbone.layers[2](x)
+    assert torch.equal(hidden, x)
+
+
+def test_middle_layer_is_the_middle_block_and_needs_blocks() -> None:
+    assert middle_layer(_Backbone(8)) == 4
+    assert middle_layer(_Backbone(1)) == 0
+    with pytest.raises(TypeError, match="block-structured"):
+        middle_layer(nn.Linear(2, 2))
+
+
+def test_steering_direction_needs_the_decomposed_bottleneck() -> None:
+    with pytest.raises(NotImplementedError, match="decomposed"):
+        steering_direction(_model("mixture"), 0)
+
+
+def test_gamma_rejects_a_non_positive_tau_and_a_direction_that_raises_nothing() -> None:
+    model = _model("decomposed")
+    direction = steering_direction(model, 0)
+    with pytest.raises(ValueError, match="positive"):
+        steering_gamma(model, direction, tau=0.0)
+    with torch.no_grad():
+        model.lm_head.weight.zero_()  # no logit can rise along any direction
+    with pytest.raises(ValueError, match="raises no logit"):
+        steering_gamma(model, direction, tau=1.0)

--- a/tests/odyssey/training/test_lifted_tokens.py
+++ b/tests/odyssey/training/test_lifted_tokens.py
@@ -1,0 +1,89 @@
+"""Lifted token sets: P(token | concept active) / P(token) over running labels."""
+
+from datetime import datetime, timedelta
+
+import polars as pl
+import torch
+
+from odyssey.data.vocabulary import Vocabulary
+from odyssey.training.data import iter_patient_sequences
+from odyssey.training.lifted_tokens import lifted_token_sets, rank_by_lift
+
+
+T0 = datetime(2024, 1, 1)
+CODES = [f"LAB//{i}//" for i in range(6)]
+K = 2
+
+
+def _events() -> pl.DataFrame:
+    """Subjects 1 and 2 emit LAB//5 only after hour 4; subject 3 never does."""
+    rows = []
+    for sid in (1, 2, 3):
+        for i in range(12):
+            code = CODES[5] if sid != 3 and i >= 4 and i % 2 == 0 else CODES[i % 5]
+            rows.append((sid, code, T0 + timedelta(hours=i), None, 100 + sid))
+    return pl.DataFrame(
+        rows,
+        schema={
+            "subject_id": pl.Int64,
+            "code": pl.Utf8,
+            "time": pl.Datetime,
+            "numeric_value": pl.Float32,
+            "hadm_id": pl.Int64,
+        },
+        orient="row",
+    )
+
+
+def _vocab() -> Vocabulary:
+    tokens = {"[PAD]": 0, "[UNK]": 1}
+    tokens.update({c: i + 2 for i, c in enumerate(CODES)})
+    return Vocabulary(tokens)
+
+
+def test_lifted_sets_follow_the_running_label_and_skip_inactive_concepts() -> None:
+    vocab = _vocab()
+    # concept 0 triggers at hour 4 for subjects 1 and 2 and never for 3;
+    # concept 1 never triggers anywhere.
+    labels = {
+        1: torch.tensor([1.0, 0.0]),
+        2: torch.tensor([1.0, 0.0]),
+        3: torch.tensor([0.0, 0.0]),
+    }
+    masks = {sid: torch.ones(K) for sid in (1, 2, 3)}
+    first = {
+        1: torch.tensor([4.0, float("inf")]),
+        2: torch.tensor([4.0, float("inf")]),
+        3: torch.tensor([float("inf"), float("inf")]),
+    }
+    sets = lifted_token_sets(
+        iter_patient_sequences(_events(), vocab),
+        vocab_size=len(vocab.token_to_id),
+        num_concepts=K,
+        concept_labels=labels,
+        concept_mask=masks,
+        concept_first_times=first,
+        supervision="stay",
+        top_k=3,
+        min_count=1,
+        min_share=0.0,
+        min_lift=1.0,
+        num_lanes=2,
+        chunk_size=8,
+        device="cpu",
+    )
+    assert set(sets) == {0, 1}
+    # LAB//5 appears only while concept 0 is active, so it has the top lift.
+    assert sets[0][0] == vocab.token_to_id[CODES[5]]
+    assert len(sets[0]) <= 3
+    assert sets[1] == []  # never active: no counts, no lifted tokens
+
+
+def test_rank_by_lift_respects_top_k_and_the_share_floor() -> None:
+    total = torch.tensor([100.0, 100.0, 100.0, 100.0])
+    per_concept = torch.tensor([[50.0, 30.0, 2.0, 0.0]])
+    sets = rank_by_lift(total, per_concept, top_k=1, min_count=1)
+    assert sets == {0: [0]}
+    # a 5% share floor drops token 2 (2 of 82 positions) even at min_count=1
+    sets = rank_by_lift(total, per_concept, top_k=5, min_count=1, min_share=0.05)
+    assert sets[0] == [0, 1]

--- a/tests/odyssey/training/test_train_steering.py
+++ b/tests/odyssey/training/test_train_steering.py
@@ -1,0 +1,254 @@
+"""CPU end-to-end run of the decomposed bottleneck with Steerling's steering phases.
+
+Exercises, on real (tiny) MEDS shards through the real training script:
+streamed shard loading, the decomposition with teacher forcing annealed
+across steps, the lifted-token count, the calibrated steering runtime,
+the steering-loss branch of the loop, init_from, and then the steering
+benchmark's ``prepare``/``evaluate_steering``/CLI against the saved run.
+"""
+
+import json
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+import pytest
+
+from odyssey.inference import steering as steering_cli
+from odyssey.inference.steering import evaluate_steering, prepare
+from odyssey.training.train import TrainingConfig, _needs_running_labels, train
+
+
+T0 = datetime(2024, 1, 1, 0, 0)
+
+
+def _write_shards(shard_dir: Path, n_subjects: int, n_events: int) -> None:
+    """Heart rates that trigger tachycardia on even subjects, bradycardia on odd."""
+    shard_dir.mkdir(parents=True, exist_ok=True)
+    rows: list[tuple[int, str, datetime, float | None, int | None]] = []
+    for subject_id in range(n_subjects):
+        base = T0 + timedelta(days=subject_id)
+        for i in range(n_events):
+            t = base + timedelta(hours=i)
+            if i % 3 == 0:
+                rate = 125.0 if subject_id % 2 == 0 else 45.0
+                rows.append((subject_id, "LAB//220045//bpm", t, rate, None))
+            elif i % 3 == 1:
+                rows.append(
+                    (
+                        subject_id,
+                        "LAB//220210//insp_min",
+                        t,
+                        15.0 + (subject_id % 10),
+                        None,
+                    )
+                )
+            else:
+                rows.append((subject_id, f"DIAGNOSIS//{i % 7}", t, None, None))
+    frame = pl.DataFrame(
+        rows,
+        schema={
+            "subject_id": pl.Int64,
+            "code": pl.Utf8,
+            "time": pl.Datetime,
+            "numeric_value": pl.Float32,
+            "hadm_id": pl.Int64,
+        },
+        orient="row",
+    )
+    frame.write_parquet(shard_dir / "0.parquet")
+
+
+def _config(
+    train_dir: Path, tuning_dir: Path, output_dir: Path, **overrides: Any
+) -> TrainingConfig:
+    defaults: dict[str, Any] = {
+        "train_shard_dir": str(train_dir),
+        "tuning_shard_dir": str(tuning_dir),
+        "output_dir": str(output_dir),
+        "backbone": "transformer",
+        "hidden_size": 16,
+        "num_hidden_layers": 2,
+        "attn_num_heads": 4,
+        "embedding_dim": 8,
+        "vocab_min_count": 1,
+        "quantile_min_count": 1,
+        "num_lanes": 2,
+        "chunk_size": 16,
+        "max_context": 32,
+        "num_epochs": 1,
+        "log_every": 2,
+        "eval_every": 1000,
+        "eval_max_chunks": 1,
+        "checkpoint_every": 1000,
+        "model_kind": "bottleneck",
+        # stay-level supervision: the synthetic shards carry no visit ids
+        "concept_supervision": "stay",
+        "bottleneck_kind": "decomposed",
+        "unknown_ratio": 2,
+        "residual_dropout": 0.3,
+        "event_hazards": True,
+        "teacher_known_start": 1.0,
+        "teacher_known_end": 0.5,
+        "teacher_unknown_start": 1.0,
+        "teacher_unknown_end": 0.5,
+        "teacher_anneal_steps": 4,
+        "orthogonality_weight": 0.0,
+    }
+    defaults.update(overrides)
+    return TrainingConfig(**defaults)
+
+
+def test_needs_running_labels_for_randint_or_steering() -> None:
+    base = {
+        "train_shard_dir": "a",
+        "tuning_shard_dir": "b",
+        "output_dir": "c",
+        "randint_prob": 0.0,
+    }
+    assert not _needs_running_labels(TrainingConfig(**base))
+    assert _needs_running_labels(TrainingConfig(**{**base, "randint_prob": 0.5}))
+    assert _needs_running_labels(TrainingConfig(**base, steering_phases=1))
+
+
+@pytest.fixture(scope="module")
+def steered_run(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Path]:
+    root = tmp_path_factory.mktemp("steer")
+    train_dir, tuning_dir = root / "data" / "train", root / "data" / "tuning"
+    _write_shards(train_dir, n_subjects=10, n_events=30)
+    _write_shards(tuning_dir, n_subjects=4, n_events=30)
+    output_dir = root / "run"
+    config = _config(
+        train_dir,
+        tuning_dir,
+        output_dir,
+        stream_shards=True,
+        steering_phases=2,
+        steering_phase_steps=2,
+        steering_warmup_steps=1,
+        steering_tau=1.0,
+        lifted_patients=6,
+        lifted_min_count=1,
+        lifted_min_share=0.0,
+        lifted_min_lift=1.0,
+    )
+    assert train(config) == output_dir
+    return {"train": train_dir, "tuning": tuning_dir, "run": output_dir}
+
+
+def test_steering_phases_train_and_log_their_losses(
+    steered_run: dict[str, Path],
+) -> None:
+    run = steered_run["run"]
+    assert (run / "checkpoint_final.pt").exists()
+    lines = [
+        json.loads(line) for line in (run / "loss_log.jsonl").read_text().splitlines()
+    ]
+    train_lines = [rec for rec in lines if rec.get("split") == "train"]
+    assert train_lines
+    steered = [rec for rec in train_lines if "respond_loss" in rec]
+    assert steered, "no logged step went through the steering-loss branch"
+    assert all(rec["respond_loss"] >= 0.0 for rec in steered)
+
+
+def test_init_from_starts_a_fresh_run_from_saved_weights(
+    steered_run: dict[str, Path], tmp_path: Path
+) -> None:
+    config = _config(
+        steered_run["train"],
+        steered_run["tuning"],
+        tmp_path / "warm",
+        init_from=str(steered_run["run"] / "checkpoint_final.pt"),
+    )
+    train(config)
+    assert (tmp_path / "warm" / "checkpoint_final.pt").exists()
+    both = _config(
+        steered_run["train"],
+        steered_run["tuning"],
+        tmp_path / "bad",
+        init_from=str(steered_run["run"] / "checkpoint_final.pt"),
+        resume_from=str(steered_run["run"] / "checkpoint_final.pt"),
+    )
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        train(both)
+
+
+def test_prepare_and_evaluate_steering_on_the_saved_run(
+    steered_run: dict[str, Path],
+) -> None:
+    prepared = prepare(
+        steered_run["run"],
+        steered_run["tuning"],
+        steered_run["train"],
+        max_shards=None,
+        lift_shards=1,
+        tau=1.0,
+        device="cpu",
+        checkpoint_path=None,
+        num_lanes=2,
+        chunk_size=16,
+        min_share=0.0,
+        min_lift=1.0,
+    )
+    assert "tachycardia" in prepared.concept_names
+    assert prepared.tables is not None
+    assert len(prepared.gammas) == len(prepared.concept_names)
+    summaries = evaluate_steering(
+        prepared,
+        concepts=["tachycardia"],
+        site="stream",
+        layer_index=0,
+        suppress_strength=None,
+        num_lanes=2,
+        chunk_size=16,
+        device="cpu",
+        n_boot=10,
+    )
+    assert [s.direction for s in summaries] == ["amplify", "suppress"]
+    assert summaries[0].n_subjects == 4
+
+
+def test_steering_cli_writes_json_and_refuses_to_overwrite(
+    steered_run: dict[str, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    out = tmp_path / "steering.json"
+    argv = [
+        "steering",
+        "--run-dir",
+        str(steered_run["run"]),
+        "--held-out-shard-dir",
+        str(steered_run["tuning"]),
+        "--lift-shard-dir",
+        str(steered_run["train"]),
+        "--output-json",
+        str(out),
+        "--concepts",
+        "tachycardia",
+        "--site",
+        "bottleneck",
+        "--num-lanes",
+        "2",
+        "--chunk-size",
+        "16",
+        "--n-boot",
+        "10",
+        "--min-share",
+        "0",
+        "--min-lift",
+        "1",
+        "--lift-shards",
+        "1",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    steering_cli._main()
+    payload = json.loads(out.read_text())
+    assert payload["site"] == "bottleneck"
+    assert [s["concept"] for s in payload["summaries"]] == [
+        "tachycardia",
+        "tachycardia",
+    ]
+    assert "tachycardia" in payload["gammas"]
+    with pytest.raises(SystemExit):
+        steering_cli._main()

--- a/tests/scripts/test_concept_atlas.py
+++ b/tests/scripts/test_concept_atlas.py
@@ -1,0 +1,109 @@
+"""Concept atlas: exact head alignment per concept and the contribution shares."""
+
+from datetime import datetime, timedelta
+
+import polars as pl
+import pytest
+import torch
+
+from odyssey.data.vocabulary import Vocabulary
+from odyssey.models.backbones.tiny_gru import TinyGRUBackbone
+from odyssey.models.sequence_model import ConceptBottleneckSequenceModel
+from scripts.concept_atlas import alignment_table, contribution_pass
+
+
+T0 = datetime(2024, 1, 1)
+CODES = [f"LAB//{i}//" for i in range(8)]
+
+
+def _vocab() -> Vocabulary:
+    tokens = {"[PAD]": 0, "[UNK]": 1}
+    tokens.update({c: i + 2 for i, c in enumerate(CODES)})
+    return Vocabulary(tokens)
+
+
+def _events() -> pl.DataFrame:
+    rows = [
+        (sid, CODES[(sid + i) % len(CODES)], T0 + timedelta(hours=i), None, 100 + sid)
+        for sid in (1, 2, 3)
+        for i in range(10)
+    ]
+    return pl.DataFrame(
+        rows,
+        schema={
+            "subject_id": pl.Int64,
+            "code": pl.Utf8,
+            "time": pl.Datetime,
+            "numeric_value": pl.Float32,
+            "hadm_id": pl.Int64,
+        },
+        orient="row",
+    )
+
+
+def _model(vocab_size: int, kind: str = "decomposed") -> ConceptBottleneckSequenceModel:
+    torch.manual_seed(0)
+    return ConceptBottleneckSequenceModel(
+        backbone=TinyGRUBackbone(vocab_size=vocab_size, hidden_size=8, padding_idx=0),
+        vocab_size=vocab_size,
+        num_concepts=3,
+        embedding_dim=4,
+        padding_idx=0,
+        bottleneck_kind=kind,
+    )
+
+
+def test_alignment_table_ranks_tokens_by_the_unit_direction_alignment() -> None:
+    torch.manual_seed(1)
+    weight = torch.randn(6, 4)  # (vocab, hidden)
+    embeddings = torch.randn(2, 4)
+    id_to_token = {i: f"tok{i}" for i in range(6)}
+    rows = alignment_table(weight, embeddings, id_to_token, {"tok0": "zero"}, top=2)
+    assert [r["index"] for r in rows] == [0, 1]
+    unit = embeddings[0] / embeddings[0].norm()
+    align = weight @ unit
+    best = int(align.argmax())
+    assert rows[0]["promotes"][0]["token"] == f"tok{best}"
+    assert rows[0]["promotes"][0]["shift"] == pytest.approx(
+        float(align.max()), abs=1e-5
+    )
+    worst = int(align.argmin())
+    assert rows[0]["suppresses"][0]["token"] == f"tok{worst}"
+    assert rows[0]["suppresses"][0]["shift"] == pytest.approx(
+        float(align.min()), abs=1e-5
+    )
+    assert rows[0]["norm"] == pytest.approx(float(embeddings[0].norm()))
+    # the description map fills in names and falls back to the token
+    for entry in rows[0]["promotes"] + rows[0]["suppresses"]:
+        expected = "zero" if entry["token"] == "tok0" else entry["token"]
+        assert entry["name"] == expected
+
+
+def test_contribution_shares_sum_to_one_and_activations_are_per_concept() -> None:
+    vocab = _vocab()
+    model = _model(len(vocab.token_to_id))
+    stats = contribution_pass(
+        model, _events(), vocab, num_lanes=2, chunk_size=8, device="cpu"
+    )
+    share = stats["contribution_share"]
+    assert stats["n_positions"] == 27  # 3 subjects x 9 next-event targets
+    assert share["named"] + share["unknown"] + share["residual"] == pytest.approx(
+        1.0, abs=1e-6
+    )
+    assert all(v >= 0 for v in share.values())
+    assert len(stats["mean_known_activation"]) == 3
+    assert len(stats["mean_unknown_activation"]) == model.bottleneck.num_unknown
+    assert all(0.0 <= a <= 1.0 for a in stats["mean_known_activation"])
+
+
+def test_contribution_pass_refuses_a_mixture_bottleneck() -> None:
+    vocab = _vocab()
+    with pytest.raises(AssertionError):
+        contribution_pass(
+            _model(len(vocab.token_to_id), kind="mixture"),
+            _events(),
+            vocab,
+            num_lanes=2,
+            chunk_size=8,
+            device="cpu",
+        )

--- a/tests/scripts/test_script_mains.py
+++ b/tests/scripts/test_script_mains.py
@@ -1,0 +1,192 @@
+"""The command-line entry points of the post-processing scripts."""
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import polars as pl
+import pytest
+
+from scripts import alerts_cis, intervention_cis, make_atlas_table, make_steering_table
+from tests.scripts.test_make_steering_table import _payload
+
+
+def _run(module, argv: list[str], monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", [module.__name__, *argv])
+    module.main()
+
+
+def test_steering_table_main_writes_before_and_after_blocks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    before, after = tmp_path / "before.json", tmp_path / "after.json"
+    before.write_text(json.dumps(_payload()))
+    after.write_text(json.dumps(_payload("suppress")))
+    out = tmp_path / "dials.tex"
+    _run(
+        make_steering_table,
+        ["--before", str(before), "--after", str(after), "--output-tex", str(out)],
+        monkeypatch,
+    )
+    text = out.read_text()
+    assert "before" in text and "after steering training" in text
+    assert text.count("aki stage 3") == 2
+
+
+def test_steering_table_main_refuses_mismatched_event_heads(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    before, after = tmp_path / "before.json", tmp_path / "after.json"
+    before.write_text(json.dumps(_payload()))
+    other = _payload()
+    other["event_names"] = ["death"]
+    after.write_text(json.dumps(other))
+    with pytest.raises(SystemExit, match="different event heads"):
+        _run(
+            make_steering_table,
+            [
+                "--before",
+                str(before),
+                "--after",
+                str(after),
+                "--output-tex",
+                str(tmp_path / "x.tex"),
+            ],
+            monkeypatch,
+        )
+
+
+def _atlas() -> dict:
+    def row(index: int, name: str) -> dict:
+        return {
+            "index": index,
+            "name": name,
+            "norm": 1.5,
+            "mean_activation": 0.4 - 0.1 * index,
+            "promotes": [
+                {
+                    "token": f"LAB//{i}//mg::Q{i}",
+                    "name": f"lab {i}",
+                    "shift": 1.0 - 0.1 * i,
+                }
+                for i in range(6)
+            ],
+            "suppresses": [
+                {"token": f"MED//{i}", "name": f"med {i}", "shift": -1.0}
+                for i in range(6)
+            ],
+        }
+
+    return {
+        "run_dir": "x",
+        "source": "mimic_iv",
+        "n_positions": 10,
+        "contribution_share": {"named": 0.1, "unknown": 0.7, "residual": 0.2},
+        "known": [row(0, "tachycardia"), row(1, "fever")],
+        "unknown": [row(0, "unknown_0"), row(1, "unknown_1"), row(2, "unknown_2")],
+    }
+
+
+def test_atlas_table_main_writes_the_requested_tables(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    atlas = tmp_path / "atlas.json"
+    atlas.write_text(json.dumps(_atlas()))
+    unknown, known = tmp_path / "unknown.tex", tmp_path / "known.tex"
+    _run(
+        make_atlas_table,
+        [
+            "--atlas",
+            str(atlas),
+            "--unknown",
+            str(unknown),
+            "--known",
+            str(known),
+            "--top-concepts",
+            "2",
+            "--top-events",
+            "3",
+        ],
+        monkeypatch,
+    )
+    printed = capsys.readouterr().out
+    assert "contribution shares: named 0.100" in printed
+    assert unknown.exists() and known.exists()
+    assert "unknown 0" in unknown.read_text() and "unknown 2" not in unknown.read_text()
+    assert "tachycardia" in known.read_text()
+
+
+def test_intervention_cis_main_pairs_the_standard_modes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    rng = np.random.default_rng(0)
+    per_subject = {
+        mode: {str(sid): [int(rng.integers(3, 8)), 8] for sid in range(20)}
+        for mode in ("none", "truth", "flip")
+    }
+    src = tmp_path / "per_subject.json"
+    src.write_text(json.dumps(per_subject))
+    out = tmp_path / "cis.json"
+    _run(
+        intervention_cis,
+        ["--per-subject", str(src), "--output-json", str(out), "--n-boot", "50"],
+        monkeypatch,
+    )
+    result = json.loads(out.read_text())
+    assert result["n_boot"] == 50
+    assert set(result["pairs"]) == {
+        "truth_minus_flip",
+        "truth_minus_none",
+        "flip_minus_none",
+    }
+    pair = result["pairs"]["truth_minus_flip"]
+    assert pair["ci_low"] <= pair["point"] <= pair["ci_high"]
+    assert pair["n_subjects"] == 20
+
+
+def test_alerts_cis_main_accepts_the_alerts_json_scorer_name_and_subsamples(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    rng = np.random.default_rng(0)
+    n_subjects, rows_per = 40, 3
+    sids = np.repeat(np.arange(n_subjects), rows_per)
+    y = np.repeat((np.arange(n_subjects) % 3 == 0).astype(float), rows_per)
+    noise = rng.uniform(0, 1, len(sids))
+    frame = pl.DataFrame(
+        {
+            "event": ["death"] * len(sids),
+            "subject_id": sids,
+            "visit_id": sids,
+            "time_hours": np.arange(len(sids), dtype=float),
+            "y@8h": y,
+            "hazard@8h": np.where(y == 1, 0.4 + 0.5 * noise, 0.1 + 0.5 * noise),
+            "gbm@8h": np.where(y == 1, 0.3 + 0.6 * noise, 0.1 + 0.6 * noise),
+        }
+    )
+    dump = tmp_path / "rows.parquet"
+    frame.write_parquet(dump)
+    out = tmp_path / "cis.json"
+    _run(
+        alerts_cis,
+        [
+            "--dump",
+            str(dump),
+            "--output-json",
+            str(out),
+            "--scorers",
+            "hazard",
+            "baseline_gbm",
+            "--n-boot",
+            "30",
+            "--max-subjects",
+            "25",
+        ],
+        monkeypatch,
+    )
+    result = json.loads(out.read_text())
+    assert result["scorers"] == ["hazard", "gbm"]
+    assert result["max_subjects"] == 25
+    cell = result["cells"]["death@8h"]
+    assert cell["n"] == 25 * rows_per
+    assert set(cell["scorers"]) == {"hazard", "gbm"}


### PR DESCRIPTION
Tests only, no code changes. Restores the coverage lost on the #217 squash merge by exercising the steering benchmark (pass, orchestration, CLI), the lifted-token count, the concept atlas, the training loop's steering runtime and streamed-shard path, the injection and steering definitions' edge cases, the decomposed bottleneck's guards, and the post-processing scripts' entry points. 33 new CPU tests; the end-to-end steering run trains a tiny decomposed transformer on synthetic MEDS shards through the real training script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KocCJujRUmyVvuoh5ushFU