### PR TITLE
Map GEMINI's lab panel so 25 of 29 concepts resolve; per-unit LOINC thresholds

### DIFF
--- a/odyssey/data/code_mapping.py
+++ b/odyssey/data/code_mapping.py
@@ -249,6 +249,27 @@ GEMINI_TO_LOINC: dict[str, str] = {
     "LAB//3018405//": "32693-4",  # Lactate, arterial (1.27M)
     "LAB//3008037//": "32693-4",  # Lactate, venous (1.22M)
     "LAB//3020138//": "32693-4",  # Lactate, serum/plasma (0.76M)
+    # -- The electrolyte / CBC / coagulation panel the v3 concepts key on.
+    # OMOP ids and names from the datacut's lab concept lookup
+    # (scripts/gemini/out/lab_lookup_unmapped.json); row counts from the
+    # code inventory. Electrolytes and bicarbonate are charted in mmol/L,
+    # which equals the mEq/L the canonical thresholds use; platelets in
+    # x10^9/L, equal to MIMIC's K/uL. Hemoglobin and glucose are SI here
+    # (g/L, mmol/L) and carry unit tags in _PREFIX_UNITS so the rules
+    # apply their SI cutoffs.
+    "LAB//3019550//": "2951-2",  # Sodium, serum/plasma (16.8M, mmol/L)
+    "LAB//3023103//": "2823-3",  # Potassium, serum/plasma (16.8M, mmol/L)
+    "LAB//3016293//": "1963-8",  # Bicarbonate, serum/plasma (13.1M, mmol/L)
+    "LAB//3007461//": "777-3",  # Platelets (13.7M, x10^9/L)
+    "LAB//3032080//": "6301-6",  # INR (4.3M; unitless)
+    # Hemoglobin: 15.1M rows in g/L against 9k in g/dL under the same id;
+    # the prefix is tagged g/L, so the handful of g/dL rows read as very
+    # low values that never cross the anemia cutoff (a false negative on
+    # 0.06% of rows, not a false positive).
+    "LAB//3000963//": "718-7",  # Hemoglobin, blood (15.1M, g/L)
+    # Serum/plasma glucose only, matching MIMIC (50931) and eICU
+    # ("glucose"); capillary glucose 3040151 stays unmapped there too.
+    "LAB//3013826//": "2345-7",  # Glucose, serum/plasma (7.8M, mmol/L)
 }
 
 
@@ -282,6 +303,10 @@ _PREFIX_UNITS: dict[str, dict[str, str]] = {
         # thresholds/ranges must NOT apply; see CANONICAL_CLINICAL_RANGES'
         # umol/L entry and the AKI rule's unit_deltas.
         "LAB//3020564//": "umol/L",
+        # Hemoglobin and glucose are SI on GEMINI; the concept rules carry
+        # matching unit_thresholds (concepts.py _HEMOGLOBIN_LOW, _GLUCOSE_*).
+        "LAB//3000963//": "g/L",
+        "LAB//3013826//": "mmol/L",
         # Body temperature: Canadian network, Celsius (no Fahrenheit rows
         # observed in the vitals unit sampling).
         "VITALS//3020891//": "C",

--- a/odyssey/data/concepts.py
+++ b/odyssey/data/concepts.py
@@ -486,11 +486,17 @@ class LoincThreshold:
     clinically interchangeable for the rule (non-invasive 76534-7 and
     arterial 8480-6 systolic BP); inside a composite, a multi-prefix
     expansion is wrapped in :class:`AnyOf` so it still counts as one
-    criterion. Exactly one of ``threshold`` (unit-unambiguous signals)
-    or ``unit_thresholds`` (unit-split signals: temperature is charted
-    in Fahrenheit or Celsius depending on source and itemid, with the
-    same LOINC 8310-5) must be given; unit tags come from
-    :func:`odyssey.data.code_mapping.unit_for`.
+    criterion. ``threshold`` applies to every prefix whose unit is
+    unambiguous (no tag from :func:`odyssey.data.code_mapping.unit_for`);
+    ``unit_thresholds`` gives the same cutoff in other units for prefixes
+    that carry a tag, the way :class:`LoincBaselineRelative.unit_deltas`
+    does for deltas. Temperature is charted in Fahrenheit or Celsius
+    depending on source and itemid under one LOINC 8310-5, so it lists
+    both units and no default; glucose and hemoglobin are mg/dL and g/dL
+    on the US sources and mmol/L and g/L on GEMINI, so they keep the
+    conventional default and add the SI cutoff. At least one of the two
+    must be given, and a tagged prefix whose unit has no entry is an
+    error rather than a silent fall-through to the wrong unit.
     """
 
     loincs: tuple[str, ...]
@@ -499,12 +505,10 @@ class LoincThreshold:
     unit_thresholds: tuple[tuple[str, float], ...] | None = None
 
     def __post_init__(self) -> None:
-        """Require exactly one of ``threshold``/``unit_thresholds``."""
-        if (self.threshold is None) == (self.unit_thresholds is None):
+        """Require a default threshold, per-unit thresholds, or both."""
+        if self.threshold is None and self.unit_thresholds is None:
             raise ValueError(
-                "LoincThreshold needs exactly one of threshold or "
-                f"unit_thresholds, got threshold={self.threshold!r} "
-                f"unit_thresholds={self.unit_thresholds!r}"
+                "LoincThreshold needs a threshold, unit_thresholds, or both"
             )
 
 
@@ -645,18 +649,26 @@ def _loinc_prefixes(loincs: tuple[str, ...], source: str) -> list[str]:
 
 
 def _prefix_threshold(rule: LoincThreshold, prefix: str, source: str) -> float:
-    """Pick the threshold that applies to one concrete prefix."""
-    if rule.unit_thresholds is None:
-        assert rule.threshold is not None  # noqa: S101 -- __post_init__ guarantees
-        return rule.threshold
+    """Pick the threshold that applies to one concrete prefix.
+
+    A tagged unit takes its own entry from ``unit_thresholds``; an
+    untagged prefix takes the default ``threshold``. A tagged prefix with
+    no entry, or an untagged prefix on a rule with no default, is a
+    configuration error: silently using the wrong unit's number would
+    make a concept fire on assay noise or never at all.
+    """
     unit = unit_for(prefix, source=source)
-    for tagged_unit, threshold in rule.unit_thresholds:
-        if tagged_unit == unit:
-            return threshold
+    if unit is not None and rule.unit_thresholds is not None:
+        for tagged_unit, threshold in rule.unit_thresholds:
+            if tagged_unit == unit:
+                return threshold
+    if unit is None and rule.threshold is not None:
+        return rule.threshold
+    listed = [u for u, _ in rule.unit_thresholds or ()]
     raise ValueError(
         f"prefix {prefix!r} in source {source!r} has unit tag {unit!r}, but "
-        f"the rule only defines thresholds for "
-        f"{[u for u, _ in rule.unit_thresholds]!r} -- add the unit tag to "
+        f"the rule defines a default threshold of {rule.threshold!r} and "
+        f"per-unit thresholds for {listed!r} -- add the unit tag to "
         f"code_mapping._PREFIX_UNITS or a threshold for that unit."
     )
 
@@ -940,6 +952,16 @@ _MAP = ("76536-2", "8478-0")  # mean arterial pressure: non-invasive OR arterial
 
 _TEMP_HIGH = (("F", 100.4), ("C", 38.0))
 _TEMP_LOW = (("F", 96.8), ("C", 36.0))
+# SI cutoffs for the sources that chart glucose in mmol/L (1 mmol/L =
+# 18.016 mg/dL) and hemoglobin in g/L; the untagged US prefixes keep the
+# conventional-unit defaults on the rules themselves.
+_GLUCOSE_LOW = (("mmol/L", 3.9),)
+_GLUCOSE_HIGH = (("mmol/L", 13.9),)
+_HEMOGLOBIN_LOW = (("g/L", 70.0),)
+# KDIGO stage-3 absolute creatinine, 4.0 mg/dL, in the umol/L GEMINI charts
+# (x 88.42). Before per-unit thresholds this rule compared umol/L values
+# against 4.0 and fired on essentially every creatinine result there.
+_CREATININE_STAGE3 = (("umol/L", 353.7),)
 
 
 CANONICAL_CONCEPTS: list[AnyCanonicalConcept] = [
@@ -1048,7 +1070,9 @@ CANONICAL_CONCEPTS: list[AnyCanonicalConcept] = [
                 _CREATININE, ratio=3.0, direction="above", window_hours=168.0
             ),
             # KDIGO: >= 4.0, inclusive
-            LoincThreshold(_CREATININE, "at_or_above", 4.0),
+            LoincThreshold(
+                _CREATININE, "at_or_above", 4.0, unit_thresholds=_CREATININE_STAGE3
+            ),
             # RRT initiation is an automatic Stage 3 in KDIGO, whatever
             # creatinine and urine output say (mimic-code's rrt.sql item ids;
             # see RRT_CODE_PATTERN). First occurrence only, which is what
@@ -1208,21 +1232,21 @@ CANONICAL_CONCEPTS: list[AnyCanonicalConcept] = [
     ),
     CanonicalConcept(
         "hypoglycemia",
-        (LoincThreshold(_GLUCOSE, "below", 70.0),),
-        "Serum/plasma glucose < 70 mg/dL -- the ADA (American Diabetes "
-        "Association) hypoglycemia threshold.",
+        (LoincThreshold(_GLUCOSE, "below", 70.0, unit_thresholds=_GLUCOSE_LOW),),
+        "Serum/plasma glucose < 70 mg/dL (3.9 mmol/L) -- the ADA (American "
+        "Diabetes Association) hypoglycemia threshold.",
     ),
     CanonicalConcept(
         "hyperglycemia",
-        (LoincThreshold(_GLUCOSE, "above", 250.0),),
-        "Serum/plasma glucose > 250 mg/dL -- a standard marked-"
+        (LoincThreshold(_GLUCOSE, "above", 250.0, unit_thresholds=_GLUCOSE_HIGH),),
+        "Serum/plasma glucose > 250 mg/dL (13.9 mmol/L) -- a standard marked-"
         "hyperglycemia threshold, well above routine stress-hyperglycemia "
         "noise and below DKA-range values.",
     ),
     CanonicalConcept(
         "anemia",
-        (LoincThreshold(_HEMOGLOBIN, "below", 7.0),),
-        "Hemoglobin < 7 g/dL -- the restrictive-transfusion-strategy "
+        (LoincThreshold(_HEMOGLOBIN, "below", 7.0, unit_thresholds=_HEMOGLOBIN_LOW),),
+        "Hemoglobin < 7 g/dL (70 g/L) -- the restrictive-transfusion-strategy "
         "trigger (TRICC/TRISS-style ICU threshold), the more specific of "
         "the two commonly-cited cutoffs (7 vs. 8 g/dL).",
     ),

--- a/tests/odyssey/data/test_code_mapping.py
+++ b/tests/odyssey/data/test_code_mapping.py
@@ -229,3 +229,18 @@ def test_gemini_prefixes_resolve_to_registry_loincs() -> None:
     assert unit_for("LAB//3020564//", source="gemini") == "umol/L"
     assert unit_for("VITALS//3020891//", source="gemini") == "C"
     assert unit_for("VITALS//3027018//", source="gemini") is None
+    # the lab panel: SI-tagged where the cutoff differs, untagged where
+    # mmol/L equals mEq/L and x10^9/L equals K/uL
+    assert loinc_for("LAB//3019550//", source="gemini") == "2951-2"  # sodium
+    assert loinc_for("LAB//3023103//", source="gemini") == "2823-3"  # potassium
+    assert loinc_for("LAB//3016293//", source="gemini") == "1963-8"  # bicarbonate
+    assert loinc_for("LAB//3007461//", source="gemini") == "777-3"  # platelets
+    assert loinc_for("LAB//3032080//", source="gemini") == "6301-6"  # INR
+    assert loinc_for("LAB//3000963//", source="gemini") == "718-7"  # hemoglobin
+    assert loinc_for("LAB//3013826//", source="gemini") == "2345-7"  # glucose
+    assert unit_for("LAB//3000963//", source="gemini") == "g/L"
+    assert unit_for("LAB//3013826//", source="gemini") == "mmol/L"
+    assert unit_for("LAB//3019550//", source="gemini") is None
+    assert (
+        loinc_for("LAB//3040151//", source="gemini") is None
+    )  # capillary glucose, as on MIMIC

--- a/tests/odyssey/data/test_concepts.py
+++ b/tests/odyssey/data/test_concepts.py
@@ -1154,6 +1154,88 @@ def test_gemini_source_resolves_all_but_gcs_dependent_concepts() -> None:
     assert len(names) == 15
 
 
+def test_gemini_v3_resolves_the_lab_panel_concepts() -> None:
+    """25 of 29 v3 concepts resolve once the electrolyte/CBC/INR ids are mapped.
+
+    The four that stay out need signals the datacut does not chart:
+    urine output (oliguria; none anywhere in the datacut), FiO2/PaO2
+    (hypoxemic respiratory failure; FiO2 is unmapped free text), mean
+    arterial pressure (shock; only systolic and diastolic are charted),
+    and sepsis3's SOFA components.
+    """
+    names = {c.name for c in concepts_for_source("gemini", task_set="v3")}
+    assert len(names) == 25
+    assert {
+        "hyperkalemia",
+        "hypokalemia",
+        "hyponatremia",
+        "hypernatremia",
+        "hypoglycemia",
+        "hyperglycemia",
+        "anemia",
+        "thrombocytopenia",
+        "coagulopathy",
+        "metabolic_acidosis",
+    } <= names
+    assert names.isdisjoint(
+        {"oliguria", "hypoxemic_respiratory_failure", "shock", "sepsis3"}
+    )
+    # metabolic acidosis keeps its bicarbonate criterion; the pH one drops
+    acidosis = next(
+        c
+        for c in concepts_for_source("gemini", task_set="v3")
+        if c.name == "metabolic_acidosis"
+    )
+    prefixes = {r.code_prefix for r in acidosis.rules}
+    assert prefixes == {"LAB//3016293//"}
+
+
+def test_gemini_shaped_events_label_the_si_lab_concepts() -> None:
+    """SI values cross the SI cutoffs (mmol/L glucose, g/L hemoglobin)."""
+    wanted = (
+        "hyponatremia",
+        "hyperkalemia",
+        "hypoglycemia",
+        "anemia",
+        "thrombocytopenia",
+        "coagulopathy",
+    )
+    concepts = [
+        c for c in concepts_for_source("gemini", task_set="v3") if c.name in wanted
+    ]
+    events = _events(
+        [
+            (1, "LAB//3019550//mmol/l", 125.0),  # sodium 125 -> hyponatremia
+            (1, "LAB//3023103//mmol/l", 6.1),  # potassium 6.1 -> hyperkalemia
+            (
+                1,
+                "LAB//3013826//mmol/l",
+                3.0,
+            ),  # glucose 3.0 mmol/L (54 mg/dL) -> hypoglycemia
+            (1, "LAB//3000963//g/l", 65.0),  # hemoglobin 65 g/L (6.5 g/dL) -> anemia
+            (1, "LAB//3007461//x10e9/l", 80.0),  # platelets 80 -> thrombocytopenia
+            (1, "LAB//3032080//inr", 2.1),  # INR 2.1 -> coagulopathy
+            (2, "LAB//3019550//mmol/l", 140.0),
+            (2, "LAB//3023103//mmol/l", 4.0),
+            (
+                2,
+                "LAB//3013826//mmol/l",
+                6.0,
+            ),  # 108 mg/dL: would be hypoglycemic under the mg/dL cutoff
+            (
+                2,
+                "LAB//3000963//g/l",
+                130.0,
+            ),  # 13 g/dL: would be anemic under the g/dL cutoff
+            (2, "LAB//3007461//x10e9/l", 250.0),
+            (2, "LAB//3032080//inr", 1.0),
+        ]
+    )
+    labels = label_concepts(events, concepts).sort("subject_id")
+    for name in wanted:
+        assert labels[name].to_list() == [1, 0], name
+
+
 def test_aki_delta_is_unit_converted_per_source() -> None:
     """KDIGO's 0.3 mg/dL rise becomes 26.5 umol/L on GEMINI, unchanged elsewhere.
 

--- a/tests/odyssey/data/test_concepts.py
+++ b/tests/odyssey/data/test_concepts.py
@@ -10,6 +10,7 @@ import pytest
 
 from odyssey.data import code_mapping
 from odyssey.data.concepts import (
+    _GLUCOSE,
     ANTIBIOTIC_ROUTE_EXCLUDE,
     CANONICAL_CONCEPTS,
     CONCEPTS,
@@ -21,6 +22,7 @@ from odyssey.data.concepts import (
     ConceptRule,
     DerivedGcsTotalRule,
     LoincBaselineRelative,
+    LoincThreshold,
     SustainedRule,
     _expand_rule,
     concepts_for_source,
@@ -1486,3 +1488,68 @@ def test_antibiotic_route_exclude_misses_real_mimic_route_abbreviations() -> Non
     # not overcorrect and start dropping real IV/PO antibiotic starts).
     assert not pattern.search("IV")
     assert not pattern.search("PO")
+
+
+# ---------------------------------------------------------------------------
+# Per-unit thresholds: a conventional-unit default plus SI overrides
+# ---------------------------------------------------------------------------
+
+
+def test_loinc_threshold_needs_a_default_or_per_unit_thresholds() -> None:
+    with pytest.raises(ValueError, match="threshold, unit_thresholds, or both"):
+        LoincThreshold(("2345-7",), "below")
+    # either alone is fine, and so are both together
+    LoincThreshold(("2345-7",), "below", 70.0)
+    LoincThreshold(("8310-5",), "above", unit_thresholds=(("C", 38.0),))
+    LoincThreshold(("2345-7",), "below", 70.0, unit_thresholds=(("mmol/L", 3.9),))
+
+
+def test_untagged_prefix_takes_the_default_and_tagged_prefix_its_own_unit() -> None:
+    """Glucose: mg/dL on the US sources, mmol/L wherever the prefix is tagged."""
+    rule = LoincThreshold(_GLUCOSE, "below", 70.0, unit_thresholds=(("mmol/L", 3.9),))
+    assert {r.threshold for r in _expand_rule(rule, "mimic_iv")} == {70.0}
+    assert {r.threshold for r in _expand_rule(rule, "eicu")} == {70.0}
+
+
+def test_tagged_prefix_without_an_entry_is_an_error_not_a_fallthrough() -> None:
+    """Creatinine is tagged umol/L on GEMINI; a mg/dL-only rule must refuse it."""
+    rule = LoincThreshold(("2160-0",), "above", 4.0)
+    with pytest.raises(ValueError, match="umol/L"):
+        _expand_rule(rule, "gemini")
+    # the temperature form (per-unit only) still refuses an untagged prefix
+    only_c = LoincThreshold(("8310-5",), "above", unit_thresholds=(("C", 38.0),))
+    with pytest.raises(ValueError, match="unit tag 'F'"):
+        _expand_rule(only_c, "mimic_iv")
+
+
+def test_hypoglycemia_hyperglycemia_and_anemia_carry_si_cutoffs() -> None:
+    by_name = {c.name: c for c in CANONICAL_CONCEPTS}
+    glucose_low = by_name["hypoglycemia"].rules[0]
+    glucose_high = by_name["hyperglycemia"].rules[0]
+    hemoglobin = by_name["anemia"].rules[0]
+    assert (glucose_low.threshold, glucose_low.unit_thresholds) == (
+        70.0,
+        (("mmol/L", 3.9),),
+    )
+    assert (glucose_high.threshold, glucose_high.unit_thresholds) == (
+        250.0,
+        (("mmol/L", 13.9),),
+    )
+    assert (hemoglobin.threshold, hemoglobin.unit_thresholds) == (7.0, (("g/L", 70.0),))
+
+
+def test_stage_3_creatinine_cutoff_is_unit_converted_on_gemini() -> None:
+    """KDIGO's absolute 4.0 mg/dL is 353.7 umol/L where creatinine is SI.
+
+    Before per-unit thresholds this rule compared GEMINI's umol/L values
+    against 4.0 and was true for essentially every creatinine result.
+    """
+    by_name = {c.name: c for c in CANONICAL_CONCEPTS}
+    absolute = [
+        r
+        for r in by_name["aki_stage_3"].rules
+        if isinstance(r, LoincThreshold) and r.threshold == 4.0
+    ]
+    assert len(absolute) == 1
+    assert [e.threshold for e in _expand_rule(absolute[0], "mimic_iv")] == [4.0]
+    assert [e.threshold for e in _expand_rule(absolute[0], "gemini")] == [353.7]

--- a/tests/scripts/test_gemini_concept_audit.py
+++ b/tests/scripts/test_gemini_concept_audit.py
@@ -34,9 +34,12 @@ def test_concept_resolution_matches_the_source_expansion() -> None:
     # Vitals-threshold concepts resolve through the LOINC layer.
     assert resolution["tachycardia"] is True
     assert resolution["acute_kidney_injury"] is True
-    # v3 lab-severity concepts have no GEMINI lab mapping yet.
-    assert resolution["hyperkalemia"] is False
-    assert resolution["shock"] is False
+    # v3 lab-severity concepts resolve through the electrolyte/CBC/INR
+    # mapping; the four that need signals the datacut lacks do not.
+    assert resolution["hyperkalemia"] is True
+    assert resolution["anemia"] is True
+    assert resolution["shock"] is False  # no mean arterial pressure
+    assert resolution["oliguria"] is False  # no urine output anywhere
     assert result["n_concepts_resolving"] == sum(resolution.values())
 
 


### PR DESCRIPTION
Two commits.

1. LOINC threshold rules take a conventional-unit default plus per-unit cutoffs (like the AKI delta's unit_deltas), and a tagged prefix with no matching cutoff is an error instead of a silent fall-through. Glucose (3.9 / 13.9 mmol/L) and hemoglobin (70 g/L) gain SI cutoffs. This surfaced a live bug: aki_stage_3's absolute creatinine criterion (>= 4.0 mg/dL) was compared against GEMINI's umol/L values unchanged, so it held for nearly every creatinine result there. Fixed (353.7 umol/L) with a regression test. Scope of the old bug: the aki_stage_3 concept label on GEMINI only; no alert event uses it (documented in docs/gemini.md by the GEMINI session).

2. GEMINI's code-to-LOINC table maps sodium, potassium, bicarbonate, platelets, INR, hemoglobin (g/L) and serum glucose (mmol/L) from the datacut's lab lookup. GEMINI's v3 registry goes from 15 to 25 concepts; oliguria, hypoxemic respiratory failure, shock and sepsis3 stay out because the datacut has no urine output, no mapped FiO2/PaO2, no mean arterial pressure, and no SOFA panel.

Tests: per-unit threshold semantics, the stage-3 regression, GEMINI resolution counts, a GEMINI-shaped labeling test in SI units, mapping and unit-tag assertions, and the concept-audit expectations. scripts/gemini/out/concept_audit.json is regenerated on the node by the GEMINI session after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KocCJujRUmyVvuoh5ushFU