### PR TITLE
Add eICU SOFA support: 26/29 -> 29/29 concept resolution

### DIFF
--- a/odyssey/data/alert_events.py
+++ b/odyssey/data/alert_events.py
@@ -96,7 +96,11 @@ ALERT_EVENTS_V1: tuple[AlertEvent, ...] = (
 
 ALERT_EVENTS_V2: tuple[AlertEvent, ...] = ALERT_EVENTS_V1 + (
     # Sepsis-3 onset from the sepsis3 concept (suspected infection + SOFA
-    # >= 2; see odyssey.data.concepts.Sepsis3Rule). MIMIC-IV only today.
+    # >= 2; see odyssey.data.concepts.Sepsis3Rule). No source gate here --
+    # this event is available wherever the concept resolves, which is
+    # MIMIC-IV and, since SOFA_SOURCE_CONFIG gained an eicu entry, eICU
+    # too; GEMINI still lacks the SOFA ingredients (see
+    # docs/gemini_extraction.md).
     AlertEvent("sepsis3", concept="sepsis3"),
     # 30-day readmission: the next hospital admission after this visit's
     # last event; scored at discharge-anchored index rows with a 720h
@@ -148,7 +152,7 @@ def alert_events_for(
     """Return the alert events a run with ``task_set`` trains heads for / scores.
 
     With ``source``, concept-backed alerts whose concept does not resolve
-    for that source are dropped (sepsis3 on eICU), and code-prefix alerts
+    for that source are dropped (sepsis3 on GEMINI), and code-prefix alerts
     are remapped to that source's own vocabulary where it needs one
     (:data:`_SOURCE_CODE_PREFIXES`; GEMINI's bare structural tokens):
     head construction, the event-time computation, and scoring must all

--- a/odyssey/data/sofa.py
+++ b/odyssey/data/sofa.py
@@ -44,7 +44,7 @@ special case of it.
 import functools
 import warnings
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import (
     Any,
     TypeVar,
@@ -69,6 +69,27 @@ class SofaSourceConfig:
     infusion_end_prefix: str
     ventilation_start: tuple[str, ...]
     ventilation_end: tuple[str, ...]
+    cardiovascular_fixed_tier: dict[str, int] = field(default_factory=dict)
+    """Score a drug's whole infusion at one fixed tier instead of reading
+    its START row's ``value`` as a mcg/kg/min rate. For a source whose
+    numeric field is not confirmed to be in that unit (free-text dosages
+    mixing boluses and continuous rates, or a rate charted per-minute
+    rather than per-kg-per-minute with no verified conversion) --
+    guessing a conversion would silently produce a wrong severity tier
+    rather than fail loudly. Keyed by drug name (``"dopamine"``,
+    ``"epinephrine"``, ``"norepinephrine"``, ``"dobutamine"``); a drug not
+    present here still uses the rate-based tiers, so this is opt-in per
+    drug, not a source-wide switch. Set the *lower* of a drug's two
+    rate-dependent tiers so the approximation never over-scores (an
+    infusion always exists at some real rate, so the true tier is always
+    >= this one); this does not affect *whether* Sepsis-3's SOFA-rise
+    criterion fires, since starting any pressor already lifts the
+    cardiovascular component by at least 2 from a baseline of 0 or 1 --
+    only the exact score is approximate. Same spirit as ``oliguria``
+    using absolute urine volume rather than KDIGO's weight-normalized
+    rate: a stated, documented simplification rather than an unverifiable
+    guess.
+    """
     daily_weight: tuple[str, ...] = ()
     """Code prefixes of the recurring charted body weight, in kg.
 
@@ -93,6 +114,10 @@ SOFA_SOURCE_CONFIG: dict[str, SofaSourceConfig] = {
         infusion_end_prefix="INFUSION_END//",
         ventilation_start=("PROCEDURE//START//225792", "PROCEDURE//START//225794"),
         ventilation_end=("PROCEDURE//END//225792", "PROCEDURE//END//225794"),
+        # Dobutamine has no rate-dependent SOFA tier (any dose scores 2);
+        # MIMIC-IV's other three pressors ARE rate-based here, chartevents'
+        # rate items being natively charted in mcg/kg/min already.
+        cardiovascular_fixed_tier={"dobutamine": 2},
         # chartevents 224639 "Daily Weight" / 226512 "Admission Weight (Kg)",
         # both charted in kg. Deliberately NOT routed through the LOINC layer:
         # both carry the same body-weight LOINC, so a LOINC lookup could not
@@ -101,6 +126,69 @@ SOFA_SOURCE_CONFIG: dict[str, SofaSourceConfig] = {
         # that distinction.
         daily_weight=("LAB//224639//",),
         admission_weight=("LAB//226512//",),
+    ),
+    "eicu": SofaSourceConfig(
+        # Vasopressor identity comes from odyssey.data.code_normalization's
+        # HICL-first normalization (the same source-of-truth
+        # odyssey.data.concepts.on_vasopressors and
+        # odyssey.data.alert_events's vasopressor_start already build on),
+        # NOT a hand-rolled name/regex match here: every real HICL entry
+        # for these four drugs (checked against
+        # odyssey/data/resources/eicu_hicl_ingredients.csv directly --
+        # e.g. HICL 2051 "norepinephrine bitartrate", 36346
+        # "norepinephrine", 37410 "norepinephrine bitar-0.9% nacl") reduces
+        # to an ingredient string starting with the drug's generic name,
+        # so a plain prefix on the post-normalization code catches every
+        # named AND HICL-resolved-but-originally-unnamed row (36% of
+        # eICU's medication rows carry no drugname at all; 94% of those
+        # carry a resolving HICL). This assumes normalize_medications=True
+        # has already run (true of every training/inference path by
+        # default, verified against maybe_normalize's call sites).
+        norepinephrine=("norepinephrine", "levophed"),
+        epinephrine=("epinephrine",),
+        dopamine=("dopamine",),
+        dobutamine=("dobutamine",),
+        infusion_start_prefix="MEDICATION//STARTED//",
+        infusion_end_prefix="MEDICATION//STOPPED//",
+        # No rate confirmed in mcg/kg/min for any of the four -- eICU's
+        # medication.dosage is free text mixing bolus doses and continuous
+        # rates in unverified units, and infusionDrug.infusionrate's own
+        # extraction comment notes some drugs are charted per-minute, not
+        # per-kg-per-minute ("Norepinephrine (mcg/min)"), with no shipped
+        # weight-based conversion. Guessing one would silently produce a
+        # wrong severity tier, so every drug here is fixed rather than
+        # rate-scored -- set to the LOWER of each drug's two
+        # rate-dependent SOFA tiers so this never over-scores (see
+        # SofaSourceConfig.cardiovascular_fixed_tier's own docstring for
+        # why this does not affect whether/when sepsis3 fires, only the
+        # exact score). Same documented-limitation spirit as oliguria's
+        # absolute-volume choice below.
+        cardiovascular_fixed_tier={
+            "dopamine": 3,
+            "epinephrine": 3,
+            "norepinephrine": 3,
+            "dobutamine": 2,
+        },
+        # eICU has no respiratoryCare/respiratoryCharting table; ventilation
+        # status comes from carePlanGeneral's periodically recharted
+        # nursing assessment (CAREPLAN_GENERAL//Ventilation//{value}), not
+        # a discrete start/end procedure event. "Ventilated"/"Spontaneous"
+        # cover the two states _intervals_to_points needs (repeated
+        # "Ventilated" readings before the next "Spontaneous" are handled
+        # there, not here -- see that function's docstring). NOT verified
+        # against a real cplitemvalue distinct-value dump: the exact
+        # capitalization here is inferred from eICU-CRD's public
+        # documentation, and a tracheostomy-ventilated patient (a
+        # "Trach - ..." value, if the real data uses one) would not match
+        # either prefix and reads as never-ventilated. Confirm both before
+        # this lands in a training run.
+        ventilation_start=("CAREPLAN_GENERAL//Ventilation//Ventilated",),
+        ventilation_end=("CAREPLAN_GENERAL//Ventilation//Spontaneous",),
+        # No recurring daily weight in eICU (the patient table has only
+        # once-per-stay admission/discharge weight); left empty, same
+        # graceful-degradation this dataclass already supports for any
+        # source without one.
+        admission_weight=("ICU_ADMISSION_WEIGHT",),
     ),
 }
 
@@ -236,6 +324,21 @@ def _intervals_to_points(
     (missing END -> capped at :data:`MAX_INFUSION_HOURS`), then sampled
     every ``step_hours`` so a 24 h worst-value window sees an active
     infusion / ventilation continuously, not only at its first row.
+
+    A source that recharts status repeatedly rather than emitting a single
+    discrete START (eICU's care-plan ventilation readings: nursing
+    re-enters "Ventilated" at every assessment, not just at intubation)
+    produces one paired-and-exploded range per repeated START, all ending
+    at the same next END -- the same points several times over, not a
+    correctness problem (a worst-in-window score is insensitive to
+    duplicates) but an avoidable memory cost at nursing-assessment
+    frequency. Deduplicated below rather than left to the caller.
+
+    A trailing START with no later END is still capped at
+    :data:`MAX_INFUSION_HOURS` -- correct for a patient discharged still
+    ventilated, but a source without a reliable end signal (a missed
+    extubation note) reads as ventilated for the full cap, not truly
+    unbounded.
     """
     if starts.height == 0:
         return starts.select(
@@ -266,7 +369,7 @@ def _intervals_to_points(
     keep = [key, pl.col("_ts").alias(time_col)] + (
         [pl.col("value")] if "value" in starts.columns else []
     )
-    return expanded.select(keep)
+    return expanded.select(keep).unique()
 
 
 @_quiet_asof
@@ -369,10 +472,13 @@ def component_observations(  # noqa: PLR0912, PLR0915
 
     dopamine = infusion_points(cfg.dopamine)
     if dopamine.height:
+        fixed = cfg.cardiovascular_fixed_tier.get("dopamine")
         parts.append(
             _scored(
                 dopamine,
-                pl.when(pl.col("value") > 15)
+                pl.lit(fixed)
+                if fixed is not None
+                else pl.when(pl.col("value") > 15)
                 .then(4)
                 .when(pl.col("value") > 5)
                 .then(3)
@@ -384,14 +490,31 @@ def component_observations(  # noqa: PLR0912, PLR0915
         )
     dobutamine = infusion_points(cfg.dobutamine)
     if dobutamine.height:
-        parts.append(_scored(dobutamine, pl.lit(2), "cardiovascular", key, time_col))
-    for items in (cfg.epinephrine, cfg.norepinephrine):
+        # Dobutamine has no rate-dependent tier in SOFA (any dose scores 2),
+        # so it is always fixed -- every SOFA_SOURCE_CONFIG entry with a
+        # non-empty dobutamine tuple must set this key.
+        parts.append(
+            _scored(
+                dobutamine,
+                pl.lit(cfg.cardiovascular_fixed_tier["dobutamine"]),
+                "cardiovascular",
+                key,
+                time_col,
+            )
+        )
+    for drug, items in (
+        ("epinephrine", cfg.epinephrine),
+        ("norepinephrine", cfg.norepinephrine),
+    ):
         pts = infusion_points(items)
         if pts.height:
+            fixed = cfg.cardiovascular_fixed_tier.get(drug)
             parts.append(
                 _scored(
                     pts,
-                    pl.when(pl.col("value") > 0.1).then(4).otherwise(3),
+                    pl.lit(fixed)
+                    if fixed is not None
+                    else pl.when(pl.col("value") > 0.1).then(4).otherwise(3),
                     "cardiovascular",
                     key,
                     time_col,
@@ -676,13 +799,13 @@ def urine_output_rate(
 
     cfg = SOFA_SOURCE_CONFIG[source]
     out = rolled.sort([key, time_col])
-    for field, alias in (
+    for weight_codes, alias in (
         (cfg.daily_weight, "_w_daily"),
         (cfg.admission_weight, "_w_admission"),
     ):
         weights = _numeric(
             events,
-            list(field),
+            list(weight_codes),
             key=key,
             code_col=code_col,
             value_col=value_col,

--- a/tests/odyssey/data/test_aki_kdigo.py
+++ b/tests/odyssey/data/test_aki_kdigo.py
@@ -30,7 +30,7 @@ from odyssey.data.concepts import (
     concepts_for_source,
     label_concepts,
 )
-from odyssey.data.sofa import urine_output_24h, urine_output_rate
+from odyssey.data.sofa import SOFA_SOURCE_CONFIG, urine_output_24h, urine_output_rate
 
 
 T0 = datetime(2024, 1, 1, 0, 0)
@@ -270,14 +270,19 @@ def test_urine_output_24h_is_the_absolute_volume_special_case() -> None:
     )
 
 
-def test_only_the_weighted_form_needs_a_source_weight_config() -> None:
+def test_only_the_weighted_form_needs_a_source_weight_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The absolute-volume form must keep working where weights are unknown.
 
-    eICU has no :data:`~odyssey.data.sofa.SOFA_SOURCE_CONFIG` entry, and
-    ``urine_output_24h`` delegates here with ``weight_normalized=False``:
-    that path must not reach for a config it has no need of. Asking for
-    the weighted form on such a source is a programming error and says
-    so, the same way every other SOFA entry point does.
+    Every source ``odyssey`` ships today has a
+    :data:`~odyssey.data.sofa.SOFA_SOURCE_CONFIG` entry now that eICU's
+    SOFA support was added, so this test removes one to keep exercising
+    the invariant the code actually encodes: the absolute-volume path
+    (what ``urine_output_24h`` and, by extension, the ``oliguria``
+    concept use) must not reach for a config it has no need of, while
+    asking for the weighted form on such a source is a programming error
+    and says so, the same way every other SOFA entry point does.
     """
     rows: list[_Row] = [(1, "URINE_OUTPUT//mL", 10.0, T0 + k * H) for k in range(0, 30)]
     absolute = urine_output_rate(
@@ -290,6 +295,8 @@ def test_only_the_weighted_form_needs_a_source_weight_config() -> None:
     # Hours 24-29 are the assessable ones; each 24 h window is left-open,
     # so it holds 24 of the hourly 10 mL readings, not 25.
     assert absolute["value"].to_list() == [240.0] * 6
+
+    monkeypatch.delitem(SOFA_SOURCE_CONFIG, "eicu")
     with pytest.raises(KeyError):
         urine_output_rate(_events(rows), source="eicu", key="subject_id")
 
@@ -527,10 +534,13 @@ def test_all_three_legs_compose_as_an_or_across_a_mixed_cohort() -> None:
 def test_urine_legs_expand_only_where_the_weight_item_ids_are_known() -> None:
     """Like sepsis3: the derived legs need a source config, the rest travels.
 
-    eICU has no :data:`~odyssey.data.sofa.SOFA_SOURCE_CONFIG` entry, so
+    GEMINI has no :data:`~odyssey.data.sofa.SOFA_SOURCE_CONFIG` entry, so
     its AKI concepts keep the creatinine legs (and the harmless
     occurrence rule, which is source-agnostic) but not the urine ones,
-    and the concept is never dropped for want of them.
+    and the concept is never dropped for want of them. eICU now has a
+    config (see :data:`~odyssey.data.sofa.SOFA_SOURCE_CONFIG`), so its
+    urine legs expand exactly like MIMIC's -- the KDIGO thresholds
+    themselves are source-independent.
     """
     stages = {
         source: {
@@ -546,17 +556,17 @@ def test_urine_legs_expand_only_where_the_weight_item_ids_are_known() -> None:
         assert isinstance(concept, ConceptDefinition)
         return [r for r in concept.rules if isinstance(r, DerivedUrineRateRule)]
 
-    assert [
-        (r.threshold, r.window_hours, r.weight_normalized)
-        for r in _urine_rules("mimic_iv", "aki_stage_3")
-    ] == [(0.3, 24.0, True), (0.0, 12.0, False)]
-    assert [
-        (r.threshold, r.window_hours) for r in _urine_rules("mimic_iv", "aki_stage_2")
-    ] == [(0.5, 12.0)]
-    assert [
-        (r.threshold, r.window_hours)
-        for r in _urine_rules("mimic_iv", "acute_kidney_injury")
-    ] == [(0.5, 6.0)]
+    for source in ("mimic_iv", "eicu"):
+        assert [
+            (r.threshold, r.window_hours, r.weight_normalized)
+            for r in _urine_rules(source, "aki_stage_3")
+        ] == [(0.3, 24.0, True), (0.0, 12.0, False)]
+        assert [
+            (r.threshold, r.window_hours) for r in _urine_rules(source, "aki_stage_2")
+        ] == [(0.5, 12.0)]
+        assert [
+            (r.threshold, r.window_hours)
+            for r in _urine_rules(source, "acute_kidney_injury")
+        ] == [(0.5, 6.0)]
     for name in _ALL_STAGES:
-        assert _urine_rules("eicu", name) == []
         assert _urine_rules("gemini", name) == []

--- a/tests/odyssey/data/test_alert_events.py
+++ b/tests/odyssey/data/test_alert_events.py
@@ -264,16 +264,19 @@ def test_hazard_events_for_appends_requested_auxiliary_events() -> None:
 def test_alert_events_are_source_resolved() -> None:
     """Concept-backed alerts drop where their concept does not resolve.
 
-    sepsis3 does not resolve on eICU, so its alert event must drop with
-    it (the R6 launch failure of 2026-08-30); code-based events and
-    resolving concept events stay, and no source means no filtering.
+    sepsis3 used to not resolve on eICU (the R6 launch failure of
+    2026-08-30, when its alert event had to be dropped along with the
+    concept); it resolves now that SOFA_SOURCE_CONFIG has an eicu entry,
+    so its alert event is present again. Code-based events and every
+    other resolving concept event stay either way, and no source means
+    no filtering.
     """
     unfiltered = alert_events_for("v3")
     assert {a.name for a in unfiltered} >= {"sepsis3", "readmission_30d"}
     eicu = alert_events_for("v3", source="eicu")
     names = {a.name for a in eicu}
-    assert "sepsis3" not in names
     assert {
+        "sepsis3",
         "vasopressor_start",
         "icu_admission",
         "acute_kidney_injury",

--- a/tests/odyssey/data/test_concepts.py
+++ b/tests/odyssey/data/test_concepts.py
@@ -1516,14 +1516,32 @@ def test_v3_eicu_expansion_resolves_every_new_concept() -> None:
 
     Every v3 LOINC-threshold concept is already mapped for eicu
     (code_mapping.py), so none of those should be dropped there. The
-    SOFA-derived ones are dropped, like sepsis3: they need ventilation
-    codes and urine-output mappings eicu's spec does not provide.
+    SOFA-derived ones (hypoxemic_respiratory_failure, oliguria) also
+    resolve now that eicu has a SofaSourceConfig entry -- see
+    test_eicu_v3_resolves_all_29_concepts below for the full count and
+    sepsis3, which is v1-era rather than a _V3_NEW_NAMES/_V3_DERIVED_NAMES
+    concept.
     """
     eicu_names = {c.name for c in concepts_for_source("eicu", task_set="v3")}
-    for name in _V3_NEW_NAMES:
+    for name in _V3_NEW_NAMES + _V3_DERIVED_NAMES:
         assert name in eicu_names, f"{name} unexpectedly dropped for eicu"
-    for name in _V3_DERIVED_NAMES:
-        assert name not in eicu_names, f"{name} unexpectedly present for eicu"
+
+
+def test_eicu_v3_resolves_all_29_concepts() -> None:
+    """All 29 v3 concepts resolve on eicu, asserted as a count, not observed.
+
+    sofa_supported("eicu") became true once SOFA_SOURCE_CONFIG gained an
+    eicu entry (vasopressor identity via the shared HICL-normalized
+    on_vasopressors path, fixed cardiovascular tiers since no eicu rate
+    field is confirmed to be mcg/kg/min, ventilation via carePlanGeneral),
+    which brings sepsis3, hypoxemic_respiratory_failure and oliguria in
+    together -- all three depend on the same gate, not three separate
+    fixes. Compare test_gemini_v3_resolves_the_lab_panel_concepts, the
+    same style of assertion for the other source with a partial registry.
+    """
+    names = {c.name for c in concepts_for_source("eicu", task_set="v3")}
+    assert len(names) == 29
+    assert {"sepsis3", "hypoxemic_respiratory_failure", "oliguria"} <= names
 
 
 # ---------------------------------------------------------------------------

--- a/tests/odyssey/data/test_sepsis3_tasks.py
+++ b/tests/odyssey/data/test_sepsis3_tasks.py
@@ -119,6 +119,65 @@ def test_sofa_vasopressor_rates_and_ventilation_and_window_decay() -> None:
     assert by_time[T0 + 43 * H] == 4  # ventilated PF < 100
 
 
+def test_sofa_eicu_vasopressor_tiers_are_fixed_not_rate_based() -> None:
+    """EICU's SofaSourceConfig scores vasopressors at a fixed tier.
+
+    No eICU numeric field is confirmed to be mcg/kg/min (see
+    SofaSourceConfig.cardiovascular_fixed_tier's docstring), so the START
+    row's ``value`` is never read for eICU -- 999.0 below would score
+    norepinephrine/epinephrine at tier 4 (> 0.1) on MIMIC-IV's rate-based
+    path; on eICU it is ignored entirely and the fixed tier (3) applies
+    regardless of the charted number. Codes are post-normalization
+    ingredient-level (odyssey.data.code_normalization), matching what
+    SOFA actually sees once normalize_medications has run -- not the raw
+    MEDICATION//STARTED//{name}//{hicl} shape.
+    """
+    rows = [
+        (1, 10, T0, "MEDICATION//STARTED//norepinephrine", 999.0),
+        (1, 10, T0 + 3 * H, "MEDICATION//STOPPED//norepinephrine", None),
+        (2, 20, T0, "MEDICATION//STARTED//dobutamine", 999.0),
+        (2, 20, T0 + 3 * H, "MEDICATION//STOPPED//dobutamine", None),
+    ]
+    obs = component_observations(_frame(rows), key="subject_id", source="eicu")
+    cardio = obs.filter(pl.col("component") == "cardiovascular")
+    scores = dict(zip(cardio["subject_id"].to_list(), cardio["score"].to_list()))
+    assert scores == {1: 3, 2: 2}
+
+
+def test_sofa_eicu_ventilation_from_careplan_general_tolerates_recharting() -> None:
+    """EICU ventilation status comes from carePlanGeneral, recharted or not.
+
+    Nursing re-enters "Ventilated" at every assessment rather than a
+    single discrete start the way MIMIC-IV's procedure events work;
+    _intervals_to_points must give the same result whether it sees one
+    start or several redundant ones before the same end (see that
+    function's own docstring on this).
+    """
+    vent_start = (
+        "CAREPLAN_GENERAL//Ventilation//Ventilated - with daily extubation evaluation"
+    )
+    vent_end = "CAREPLAN_GENERAL//Ventilation//Spontaneous - adequate"
+    pao2, fio2 = "LAB//paO2//mmHg", "LAB//FiO2//UNK"
+    single = [
+        (1, 10, T0, vent_start, None),
+        (1, 10, T0 + H, fio2, 100.0),
+        (1, 10, T0 + 2 * H, pao2, 90.0),  # PF 90, ventilated -> 4
+        (1, 10, T0 + 5 * H, vent_end, None),
+    ]
+    recharted = [
+        (2, 20, T0, vent_start, None),
+        (2, 20, T0 + H, vent_start, None),  # same status, recharted
+        (2, 20, T0 + 2 * H, vent_start, None),  # recharted again
+        (2, 20, T0 + 3 * H, fio2, 100.0),
+        (2, 20, T0 + 4 * H, pao2, 90.0),
+        (2, 20, T0 + 5 * H, vent_end, None),
+    ]
+    single_ts = sofa_timeseries(_frame(single), key="subject_id", source="eicu")
+    recharted_ts = sofa_timeseries(_frame(recharted), key="subject_id", source="eicu")
+    assert single_ts["sofa"].to_list()[-1] == 4
+    assert recharted_ts["sofa"].to_list()[-1] == 4
+
+
 def test_sofa_urine_output_needs_24h_of_record() -> None:
     rows = [(1, 10, T0, CREAT, 0.8)] + [
         (1, 10, T0 + k * H, URINE, 10.0) for k in range(1, 30)
@@ -256,9 +315,11 @@ def test_task_sets_are_versioned_and_backward_compatible() -> None:
     assert v1 == list(TASK_SETS["v1"]) and len(v1) == 15
     v2 = [c.name for c in concepts_for_source("mimic_iv", task_set="v2")]
     assert v2 == v1 + ["sepsis3"]
-    assert [c.name for c in concepts_for_source("eicu", task_set="v2")] == [
-        c.name for c in concepts_for_source("eicu")
-    ]  # no SOFA ingredients on eICU: sepsis3 dropped, v2 == v1 there
+    eicu_v1 = [c.name for c in concepts_for_source("eicu")]
+    eicu_v2 = [c.name for c in concepts_for_source("eicu", task_set="v2")]
+    assert eicu_v2 == eicu_v1 + [
+        "sepsis3"
+    ]  # eICU has a SOFA_SOURCE_CONFIG entry now, same v1->v2 shape as MIMIC-IV
     with pytest.raises(ValueError, match="unknown task_set"):
         concepts_for_source("mimic_iv", task_set="v9")
     assert ALERT_EVENTS is ALERT_EVENTS_V1 and alert_events_for("v1") is ALERT_EVENTS_V1
@@ -410,5 +471,11 @@ def test_oliguria_needs_a_full_day_of_record_and_sums_the_window() -> None:
 def test_derived_signal_concepts_are_dropped_where_sofa_is_unsupported() -> None:
     v3 = [c.name for c in concepts_for_source("mimic_iv", task_set="v3")]
     assert {"hypoxemic_respiratory_failure", "oliguria"} <= set(v3)
+    # eICU has a SOFA_SOURCE_CONFIG entry, so it is a second positive case
+    # here, not the negative one -- GEMINI still lacks SOFA ingredients
+    # (docs/gemini_extraction.md), so it is the source that still drops
+    # these two.
     eicu = [c.name for c in concepts_for_source("eicu", task_set="v3")]
-    assert not ({"hypoxemic_respiratory_failure", "oliguria"} & set(eicu))
+    assert {"hypoxemic_respiratory_failure", "oliguria"} <= set(eicu)
+    gemini = [c.name for c in concepts_for_source("gemini", task_set="v3")]
+    assert not ({"hypoxemic_respiratory_failure", "oliguria"} & set(gemini))

--- a/tests/odyssey/training/test_train.py
+++ b/tests/odyssey/training/test_train.py
@@ -822,9 +822,14 @@ def test_batch_config_fields_excludes_non_resume_relevant_hyperparameters() -> N
 def test_sidecar_gate_is_source_resolved(tmp_path: Path) -> None:
     """The sepsis3/microbiology sidecar guard follows source resolution.
 
-    task_set v3 supervises sepsis3 on MIMIC-IV (sidecar required) but
-    sepsis3 drops on eICU, where the same task_set must train without
-    the sidecar (the R6 launch failure of 2026-08-30).
+    task_set v3 supervises sepsis3 on MIMIC-IV and, since
+    SOFA_SOURCE_CONFIG gained an eicu entry, on eICU too -- both need the
+    sidecar now (originally the R6 launch failure of 2026-08-30 was
+    exactly this guard catching MIMIC-IV missing one; eICU used to be the
+    source where the same task_set trained without it, before this fix).
+    GEMINI still lacks the SOFA ingredients sepsis3 needs
+    (docs/gemini_extraction.md), so it is the new control case: same
+    task_set, guard correctly does not fire.
     """
     base = {
         "train_shard_dir": str(tmp_path),
@@ -834,11 +839,12 @@ def test_sidecar_gate_is_source_resolved(tmp_path: Path) -> None:
     }
     try:
         train_module._activate_run_sidecars(
-            TrainingConfig(source="eicu", **base)  # type: ignore[arg-type]
+            TrainingConfig(source="gemini", **base)  # type: ignore[arg-type]
         )
-        with pytest.raises(FileNotFoundError, match="microbiology"):
-            train_module._activate_run_sidecars(
-                TrainingConfig(source="mimic_iv", **base)  # type: ignore[arg-type]
-            )
+        for source in ("mimic_iv", "eicu"):
+            with pytest.raises(FileNotFoundError, match="microbiology"):
+                train_module._activate_run_sidecars(
+                    TrainingConfig(source=source, **base)  # type: ignore[arg-type]
+                )
     finally:
         activate_sidecars(None)


### PR DESCRIPTION
## Summary
- eICU had no `SofaSourceConfig` entry, so `sofa_supported("eicu")` was `False` and every SOFA-derived concept (`sepsis3`, `hypoxemic_respiratory_failure`, `oliguria`) silently dropped out of eICU's registry despite the underlying LOINC mappings (PaO2, FiO2, urine output) already being present.
- Adds a `SofaSourceConfig` for `eicu`: vasopressors resolved through the existing HICL/name normalization layer, scored at a conservative fixed tier per drug (no verified mcg/kg/min convention in the eICU extract, so the exact SOFA magnitude is approximate; onset timing is unaffected since starting any pressor already lifts the cardiovascular component by >=2 from baseline); ventilation status read from `carePlanGeneral`, tolerant of eICU's recharted (repeated) status entries via a dedupe fix in `_intervals_to_points`.
- Updates 6 downstream tests whose assumptions were genuinely invalidated by the fix (not masked/hacked around).

## Consequence flagged, not yet resolved
eICU `task_set=v3` training now requires a microbiology sidecar for the `sepsis3` supervision gate, same as MIMIC-IV. None exists yet — only `scripts/build_mimic_sidecars.py`, which is MIMIC-only. Any future eICU v3 training run will hard-fail at `_activate_run_sidecars()` until one is built.

## Test plan
- [x] `uv run pytest tests/odyssey/data/test_aki_kdigo.py tests/odyssey/data/test_alert_events.py tests/odyssey/data/test_concepts.py tests/odyssey/data/test_sepsis3_tasks.py tests/odyssey/training/test_train.py` — all pass
- [x] `uv run pre-commit run --all-files` — ruff/mypy/pytest all green (in a clean worktree; `HANDOFF.md`'s pre-existing unrelated typo is the only local gate failure and predates this branch)
- [x] Live-verified `concepts_for_source('eicu', task_set='v3')` resolves 29/29 (was 26/29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNVjG3k8QELJWH2dJDtJeT