### PR TITLE
Cut atlas table cells at word boundaries; tighten the lever table

### DIFF
--- a/scripts/make_atlas_table.py
+++ b/scripts/make_atlas_table.py
@@ -41,7 +41,11 @@ def short_name(name: str, limit: int = 34) -> str:
         name = re.sub(pat, rep, name)
     name = name.strip()
     if len(name) > limit:
-        name = name[: limit - 1].rstrip() + "…"
+        # Cut at a word boundary so a cell never ends mid-word.
+        cut = name[: limit - 1]
+        if " " in cut[limit // 2 :]:
+            cut = cut[: cut.rfind(" ")]
+        name = cut.rstrip() + "…"
     return (
         name.replace("&", "\\&")
         .replace("%", "\\%")

--- a/scripts/make_lever_table.py
+++ b/scripts/make_lever_table.py
@@ -54,7 +54,7 @@ def _load(path: Path) -> Any:
 def _fmt(pair: dict[str, Any] | None) -> str:
     if pair is None:
         return "--"
-    text = f"${100 * pair['point']:+.2f}$ [{100 * pair['ci_low']:+.2f}, {100 * pair['ci_high']:+.2f}]"
+    text = f"${100 * pair['point']:+.2f}$ [{100 * pair['ci_low']:+.2f},{100 * pair['ci_high']:+.2f}]"
     return f"\\textbf{{{text}}}" if pair.get("separated") else text
 
 

--- a/tests/scripts/test_make_lever_table.py
+++ b/tests/scripts/test_make_lever_table.py
@@ -57,7 +57,7 @@ def test_ci_rows_are_bold_when_separated_and_point_rows_are_starred(
     ]
     assert len(lines) == 2  # the arm with nothing banked is skipped
     with_cis, points = lines
-    assert with_cis.startswith("With CIs & \\textbf{$-0.15$ [-0.16, -0.14]}")
-    assert "$+0.02$ [-0.06, +0.11]" in with_cis and "\\textbf{$+0.02$" not in with_cis
+    assert with_cis.startswith("With CIs & \\textbf{$-0.15$ [-0.16,-0.14]}")
+    assert "$+0.02$ [-0.06,+0.11]" in with_cis and "\\textbf{$+0.02$" not in with_cis
     assert with_cis.rstrip(" \\").endswith("$+0.016$")  # loss delta from the band file
     assert points.startswith("Points only$^\\ast$ & $+0.52$ & $+0.07$ & --")


### PR DESCRIPTION
Two small paper-table generator fixes from the round-3 layout review: atlas cells no longer end mid-word, and the lever table's intervals fit a scriptsize two-column table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KocCJujRUmyVvuoh5ushFU