### PR TITLE
Steering benchmark: stratify dials by a concept's running label

### DIFF
--- a/odyssey/inference/steering.py
+++ b/odyssey/inference/steering.py
@@ -370,8 +370,8 @@ class PositionStrata:
         return (active > 0).long()
 
 
+# Subject id, or (subject id, stratum) when a pass is stratified.
 ReadoutKey = int | tuple[int, int]
-"""Subject id, or ``(subject id, stratum)`` when a pass is stratified."""
 
 
 def run_steering_pass(
@@ -436,8 +436,8 @@ def run_steering_pass(
                     (int(sid), sids == sid) for sid in torch.unique(sids).tolist()
                 ]
             else:
-                strat = strata.of(chunk)[real]
-                combined = sids * 2 + strat
+                stratum_ids = strata.of(chunk)[real]
+                combined = sids * 2 + stratum_ids
                 groups = [
                     ((int(code) // 2, int(code) % 2), combined == code)
                     for code in torch.unique(combined).tolist()

--- a/odyssey/inference/steering.py
+++ b/odyssey/inference/steering.py
@@ -952,7 +952,9 @@ def _split_by_stratum(
                 {int(k): v for k, v in steered.items() if isinstance(k, int)},
             )
         ]
-    out = []
+    out: list[
+        tuple[str | None, dict[int, SubjectReadout], dict[int, SubjectReadout]]
+    ] = []
     for value in (0, 1):
         base = {
             k[0]: v

--- a/odyssey/inference/steering.py
+++ b/odyssey/inference/steering.py
@@ -807,8 +807,8 @@ def prepare(
         )
     strata: PositionStrata | None = None
     if stratify_concept is not None:
-        strat_name = canonical_concept_name(stratify_concept)
-        if strat_name not in concept_names:
+        stratum_name = canonical_concept_name(stratify_concept)
+        if stratum_name not in concept_names:
             raise ValueError(
                 f"stratify concept {stratify_concept!r} is not in this run's registry"
             )
@@ -816,8 +816,8 @@ def prepare(
             held_raw, concepts, supervision
         )
         strata = PositionStrata(
-            name=strat_name,
-            concept_index=concept_names.index(strat_name),
+            name=stratum_name,
+            concept_index=concept_names.index(stratum_name),
             labels=held_labels,
             mask=held_mask,
             first_times=held_first,

--- a/odyssey/inference/steering.py
+++ b/odyssey/inference/steering.py
@@ -104,6 +104,7 @@ from odyssey.training.data import (
 )
 from odyssey.training.event_targets import EventTimeTables, event_hazard_targets
 from odyssey.training.lifted_tokens import lifted_token_sets
+from odyssey.training.running_labels import position_running_labels
 
 
 logger = logging.getLogger(__name__)
@@ -334,6 +335,45 @@ def _forward_pushed(
     return logits, out.concept_probs, out.bottleneck, new_state
 
 
+@dataclass
+class PositionStrata:
+    """Split every scored position by whether a concept has already triggered.
+
+    The stratum is the concept's running label at the position (1 once it
+    has triggered for that patient or visit, 0 before), from the same
+    label dictionaries the training loop uses. Built to test whether a
+    dial's sign depends on treatment already under way: a low mean
+    arterial pressure on MIMIC-IV is usually a patient already on
+    vasopressors, and the at-risk rule removes those patients from the
+    vasopressor outcome but not from death or ICU admission.
+    """
+
+    name: str
+    concept_index: int
+    labels: ConceptLabelDict
+    mask: ConceptLabelDict
+    first_times: ConceptLabelDict
+    supervision: ConceptSupervision
+    num_concepts: int
+
+    def of(self, chunk: StreamingChunk) -> torch.Tensor:
+        """``(lanes, T)`` long: 1 where the concept has triggered by that position."""
+        labels, observed = position_running_labels(
+            chunk,
+            self.labels,
+            self.mask,
+            self.first_times,
+            supervision=self.supervision,
+            num_concepts=self.num_concepts,
+        )
+        active = labels[..., self.concept_index] * observed[..., self.concept_index]
+        return (active > 0).long()
+
+
+ReadoutKey = int | tuple[int, int]
+"""Subject id, or ``(subject id, stratum)`` when a pass is stratified."""
+
+
 def run_steering_pass(
     model: ConceptBottleneckSequenceModel,
     events_binned: pl.DataFrame,
@@ -346,7 +386,8 @@ def run_steering_pass(
     chunk_size: int = 256,
     device: str = "cuda",
     max_seq_len: int | None = None,
-) -> dict[int, SubjectReadout]:
+    strata: PositionStrata | None = None,
+) -> dict[ReadoutKey, SubjectReadout]:
     """Stream every held-out patient once under ``push`` (``None`` = unsteered).
 
     The same sampler and state carrying as every other scorer, so a pushed
@@ -362,7 +403,7 @@ def run_steering_pass(
         chunk_size=chunk_size,
         reset_prob=0.0,
     )
-    readouts: dict[int, SubjectReadout] = {}
+    readouts: dict[ReadoutKey, SubjectReadout] = {}
     lifted = [ids.to(device) for ids in lifted_sets]
     state: Any = None
     with torch.no_grad():
@@ -390,9 +431,19 @@ def run_steering_pass(
             )
             sids = chunk.subject_ids[real]
             probs_real = probs[real]
-            for sid in torch.unique(sids).tolist():
-                sel = sids == sid
-                readouts.setdefault(int(sid), SubjectReadout()).add(
+            if strata is None:
+                groups: list[tuple[ReadoutKey, torch.Tensor]] = [
+                    (int(sid), sids == sid) for sid in torch.unique(sids).tolist()
+                ]
+            else:
+                strat = strata.of(chunk)[real]
+                combined = sids * 2 + strat
+                groups = [
+                    ((int(code) // 2, int(code) % 2), combined == code)
+                    for code in torch.unique(combined).tolist()
+                ]
+            for key, sel in groups:
+                readouts.setdefault(key, SubjectReadout()).add(
                     probs_real[sel], mass[sel], risk[sel], at_risk[sel]
                 )
     return readouts
@@ -528,6 +579,8 @@ class ConceptSteeringSummary:
     express_steered: float
     express_delta: PairedDelta
     outcomes: list[OutcomeShift] = field(default_factory=list)
+    stratum: str | None = None
+    """``name=0``/``name=1`` when the pass was split by a concept's running label."""
 
     @property
     def sign_agreement(self) -> float | None:
@@ -604,7 +657,8 @@ def clinician_line(summary: ConceptSteeringSummary) -> str:
     """One readable line per dial: what moved, which way, whether it should have."""
     ratio = summary.express_steered / max(summary.express_baseline, 1e-9)
     parts = [
-        f"{summary.concept} {'up' if summary.direction == 'amplify' else 'down'}: "
+        (f"[{summary.stratum}] " if summary.stratum else "")
+        + f"{summary.concept} {'up' if summary.direction == 'amplify' else 'down'}: "
         f"k_c {summary.respond_baseline:.2f}->{summary.respond_steered:.2f}, "
         f"lifted mass x{ratio:.2f}"
     ]
@@ -642,6 +696,8 @@ class SteeringPrepared:
     tables: EventTimeTables | None
     """Event onsets on the held-out split, for the at-risk restriction."""
     token_names: dict[str, str]
+    strata: PositionStrata | None = None
+    """Set when the benchmark is split by a concept's running label."""
 
 
 def _labels_for(
@@ -670,8 +726,13 @@ def prepare(
     metadata_dir: str | Path | None = None,
     min_share: float = 0.005,
     min_lift: float = 2.0,
+    stratify_concept: str | None = None,
 ) -> SteeringPrepared:
-    """Load the run, bin the held-out split, and build the lifted token sets."""
+    """Load the run, bin the held-out split, and build the lifted token sets.
+
+    ``stratify_concept`` names a registry concept whose running label on
+    the held-out split splits every scored position into two strata.
+    """
     model, vocab, binner, config = load_run(
         run_dir, device=device, checkpoint_path=checkpoint_path
     )
@@ -744,6 +805,25 @@ def prepare(
             all_event_times(held_raw, alerts, source, task_set=config.task_set),
             names,
         )
+    strata: PositionStrata | None = None
+    if stratify_concept is not None:
+        strat_name = canonical_concept_name(stratify_concept)
+        if strat_name not in concept_names:
+            raise ValueError(
+                f"stratify concept {stratify_concept!r} is not in this run's registry"
+            )
+        held_labels, held_mask, held_first = _labels_for(
+            held_raw, concepts, supervision
+        )
+        strata = PositionStrata(
+            name=strat_name,
+            concept_index=concept_names.index(strat_name),
+            labels=held_labels,
+            mask=held_mask,
+            first_times=held_first,
+            supervision=supervision,
+            num_concepts=len(concept_names),
+        )
     del held_raw
     return SteeringPrepared(
         model=model,
@@ -759,6 +839,7 @@ def prepare(
         supervision=supervision,
         tables=tables,
         token_names=token_names,
+        strata=strata,
     )
 
 
@@ -773,8 +854,13 @@ def evaluate_steering(
     chunk_size: int,
     device: str,
     n_boot: int,
+    stratify: PositionStrata | None = None,
 ) -> list[ConceptSteeringSummary]:
-    """Unsteered pass once, then amplify and suppress each requested concept."""
+    """Unsteered pass once, then amplify and suppress each requested concept.
+
+    With ``stratify``, every dial is summarized separately over the
+    positions before and after that concept has triggered.
+    """
     names = prepared.concept_names
     chosen = [
         canonical_concept_name(c)
@@ -802,6 +888,7 @@ def evaluate_steering(
         num_lanes=num_lanes,
         chunk_size=chunk_size,
         device=device,
+        strata=stratify,
     )
     summaries: list[ConceptSteeringSummary] = []
     for column, (concept, c) in enumerate(zip(chosen, indices, strict=True)):
@@ -828,22 +915,58 @@ def evaluate_steering(
                 num_lanes=num_lanes,
                 chunk_size=chunk_size,
                 device=device,
+                strata=stratify,
             )
-            summary = summarize_push(
-                baseline,
-                steered,
-                concept=concept,
-                concept_index=c,
-                lifted_column=column,
-                direction=direction,
-                gamma=signed,
-                site=site,
-                event_names=prepared.event_names,
-                n_boot=n_boot,
-            )
-            logger.info("[steering] %s", clinician_line(summary))
-            summaries.append(summary)
+            for stratum, base_part, steer_part in _split_by_stratum(
+                baseline, steered, stratify
+            ):
+                summary = summarize_push(
+                    base_part,
+                    steer_part,
+                    concept=concept,
+                    concept_index=c,
+                    lifted_column=column,
+                    direction=direction,
+                    gamma=signed,
+                    site=site,
+                    event_names=prepared.event_names,
+                    n_boot=n_boot,
+                )
+                summary.stratum = stratum
+                logger.info("[steering] %s", clinician_line(summary))
+                summaries.append(summary)
     return summaries
+
+
+def _split_by_stratum(
+    baseline: Mapping[ReadoutKey, SubjectReadout],
+    steered: Mapping[ReadoutKey, SubjectReadout],
+    strata: PositionStrata | None,
+) -> list[tuple[str | None, dict[int, SubjectReadout], dict[int, SubjectReadout]]]:
+    """One (label, baseline, steered) triple per stratum, keyed by subject."""
+    if strata is None:
+        return [
+            (
+                None,
+                {int(k): v for k, v in baseline.items() if isinstance(k, int)},
+                {int(k): v for k, v in steered.items() if isinstance(k, int)},
+            )
+        ]
+    out = []
+    for value in (0, 1):
+        base = {
+            k[0]: v
+            for k, v in baseline.items()
+            if isinstance(k, tuple) and k[1] == value
+        }
+        steer = {
+            k[0]: v
+            for k, v in steered.items()
+            if isinstance(k, tuple) and k[1] == value
+        }
+        if base and steer:
+            out.append((f"{strata.name}={value}", base, steer))
+    return out
 
 
 def _to_json(summaries: Sequence[ConceptSteeringSummary]) -> list[dict[str, Any]]:
@@ -920,6 +1043,11 @@ def _main() -> None:
     parser.add_argument("--chunk-size", type=int, default=256)
     parser.add_argument("--n-boot", type=int, default=1000)
     parser.add_argument("--checkpoint", default=None)
+    parser.add_argument(
+        "--stratify-by",
+        default=None,
+        help="registry concept whose running label splits every dial into two strata",
+    )
     parser.add_argument("--overwrite", action="store_true")
     args = parser.parse_args()
     logging.basicConfig(
@@ -949,6 +1077,7 @@ def _main() -> None:
         metadata_dir=metadata_dir,
         min_share=args.min_share,
         min_lift=args.min_lift,
+        stratify_concept=args.stratify_by,
     )
     layer_index = args.layer_index
     if args.site == "stream" and layer_index is None:
@@ -966,9 +1095,11 @@ def _main() -> None:
         chunk_size=args.chunk_size,
         device=device,
         n_boot=args.n_boot,
+        stratify=prepared.strata,
     )
     payload = {
         "site": args.site,
+        "stratify_by": prepared.strata.name if prepared.strata else None,
         "layer_index": layer_index,
         "tau": args.tau,
         "suppress_strength": args.suppress_strength,

--- a/tests/odyssey/inference/test_steering_pass.py
+++ b/tests/odyssey/inference/test_steering_pass.py
@@ -18,6 +18,7 @@ from odyssey.data.vocabulary import Vocabulary
 from odyssey.inference.steering import (
     CLINICAL_EXPECTATIONS,
     HORIZONS_HOURS,
+    PositionStrata,
     SteeringPrepared,
     SteeringPush,
     SubjectReadout,
@@ -259,3 +260,77 @@ def test_labels_for_builds_stay_and_visit_dictionaries() -> None:
         assert len(labels) == len(mask) == len(first)
         row = next(iter(labels.values()))
         assert row.shape[-1] == len(concepts)
+
+
+def _strata() -> PositionStrata:
+    """Concept 0 has triggered by hour 3 for subjects 1 and 2, never for 3 and 4."""
+    inf = float("inf")
+    return PositionStrata(
+        name="tachycardia",
+        concept_index=0,
+        labels={
+            1: torch.tensor([1.0, 0.0, 0.0]),
+            2: torch.tensor([1.0, 0.0, 0.0]),
+            3: torch.zeros(3),
+            4: torch.zeros(3),
+        },
+        mask={sid: torch.ones(3) for sid in (1, 2, 3, 4)},
+        first_times={
+            1: torch.tensor([3.0, inf, inf]),
+            2: torch.tensor([3.0, inf, inf]),
+            3: torch.full((3,), inf),
+            4: torch.full((3,), inf),
+        },
+        supervision="stay",
+        num_concepts=3,
+    )
+
+
+def test_stratified_pass_splits_each_subject_by_the_running_label() -> None:
+    vocab = _vocab()
+    model = _model(len(vocab.token_to_id))
+    readouts = run_steering_pass(
+        model,
+        _events(),
+        vocab,
+        push=None,
+        lifted_sets=[torch.tensor([2])],
+        tables=None,
+        num_lanes=2,
+        chunk_size=8,
+        device="cpu",
+        strata=_strata(),
+    )
+    assert set(readouts) == {(1, 0), (1, 1), (2, 0), (2, 1), (3, 0), (4, 0)}
+    # subject 1: ten events, nine targets; the concept triggers at hour 3, so
+    # three positions (hours 0-2) sit before it and six on or after it
+    assert readouts[(1, 0)].n == 3 and readouts[(1, 1)].n == 6
+    assert readouts[(3, 0)].n == 9
+
+
+def test_evaluate_steering_reports_one_summary_per_stratum() -> None:
+    vocab = _vocab()
+    model = _model(len(vocab.token_to_id))
+    prepared = _prepared(model, vocab)
+    prepared.strata = _strata()
+    summaries = evaluate_steering(
+        prepared,
+        concepts=["fever"],
+        site="bottleneck",
+        layer_index=None,
+        suppress_strength=None,
+        num_lanes=2,
+        chunk_size=8,
+        device="cpu",
+        n_boot=10,
+        stratify=prepared.strata,
+    )
+    assert [(s.direction, s.stratum) for s in summaries] == [
+        ("amplify", "tachycardia=0"),
+        ("amplify", "tachycardia=1"),
+        ("suppress", "tachycardia=0"),
+        ("suppress", "tachycardia=1"),
+    ]
+    assert summaries[0].n_subjects == 4 and summaries[1].n_subjects == 2
+    assert "[tachycardia=1]" in clinician_line(summaries[1])
+    assert _to_json(summaries)[1]["stratum"] == "tachycardia=1"


### PR DESCRIPTION
Adds --stratify-by <concept> to the steering benchmark so each dial is summarized separately before and after that concept has triggered for the patient. First use: testing whether MIMIC-IV's mis-signed dials (sustained MAP hypotension, elevated lactate) depend on the patient already being on vasopressors. Tests cover the stratified pass keys and per-stratum summaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KocCJujRUmyVvuoh5ushFU