### PR TITLE
Steering phases: keep the forecast losses off the injected positions

### DIFF
--- a/odyssey/models/sequence_model.py
+++ b/odyssey/models/sequence_model.py
@@ -27,6 +27,7 @@ Both models support two training regimes:
   Section 05.
 """
 
+import dataclasses
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import (
@@ -805,6 +806,7 @@ class ConceptBottleneckSequenceModel(_SequenceModelBase):
         event_targets: Optional["EventHazardTargets"] = None,
         respond_weight: float = 1.0,
         express_weight: float = 1.0,
+        forecast_at_injected: bool = True,
     ) -> tuple[torch.Tensor, dict[str, torch.Tensor], TimeAwareState]:
         """Steerling's steering-phase objective for one chunk (their Eqs. 31-33).
 
@@ -817,6 +819,17 @@ class ConceptBottleneckSequenceModel(_SequenceModelBase):
         probability mass on the concept's lifted tokens so the output moves
         toward events that express it. The interpretability losses are not
         computed here; Steerling switches them off during steering phases.
+
+        ``forecast_at_injected`` keeps the forecasting losses on the
+        injected positions (Steerling's Eq. 33 as written). Our injected
+        positions are ones where the concept has already triggered, so
+        there the push adds nothing the input does not already say and
+        the forecast targets are unchanged; scoring them under injection
+        teaches the network that the push changes nothing, which is the
+        opposite of what a dial needs. With ``False`` the next-event,
+        time, hazard and value losses are scored on the real positions
+        that were not injected, and the injected positions carry only
+        respond and express.
         """
         objective = objective or ForecastObjective()
         push = (gamma * direction).to(chunk.batch.concept_ids.device)
@@ -825,13 +838,26 @@ class ConceptBottleneckSequenceModel(_SequenceModelBase):
             logits, bottleneck_out, new_state = self(
                 chunk.batch, state=state, reset_mask=chunk.reset_mask
             )
-        next_token_loss = self._streaming_task_loss(logits, chunk, objective)
+        scored = chunk
+        if not forecast_at_injected:
+            keep = ~injected.to(chunk.real_mask.device)
+            # Both the real mask and the targets: the plain next-token path
+            # scores every non-padding target, not only the real positions.
+            scored = chunk._replace(
+                real_mask=chunk.real_mask & keep,
+                targets=chunk.targets.masked_fill(~keep, self.padding_idx),
+            )
+            if event_targets is not None:
+                event_targets = dataclasses.replace(
+                    event_targets, at_risk=event_targets.at_risk & keep.unsqueeze(-1)
+                )
+        next_token_loss = self._streaming_task_loss(logits, scored, objective)
         head_feats = bottleneck_out.bottleneck
-        time_loss, _ = self._streaming_time_loss(self.time_head, head_feats, chunk)
+        time_loss, _ = self._streaming_time_loss(self.time_head, head_feats, scored)
         event_loss = self._streaming_event_loss(
             self.event_heads, head_feats, event_targets
         )
-        value_loss, _ = self._streaming_value_loss(self.value_head, head_feats, chunk)
+        value_loss, _ = self._streaming_value_loss(self.value_head, head_feats, scored)
         forecast_loss = (
             next_token_loss
             + objective.time_weight * time_loss

--- a/odyssey/training/train.py
+++ b/odyssey/training/train.py
@@ -302,6 +302,11 @@ class TrainingConfig:
     """First backbone block whose output is pushed; ``None`` = the middle."""
     respond_weight: float = 1.0
     express_weight: float = 1.0
+    steering_forecast_at_injected: bool = True
+    """Score the forecasting losses on injected positions during steering
+    phases (Steerling's Eq. 33 as written). ``False`` scores them on the
+    other real positions only, so an injected position is trained to
+    respond and express and not also to leave its forecast unchanged."""
     lifted_top_k: int = 25
     lifted_min_count: int = 20
     lifted_min_share: float = 0.005
@@ -1621,6 +1626,7 @@ def _run_training(  # noqa: PLR0912, PLR0915
                     event_targets=event_targets,
                     respond_weight=config.respond_weight,
                     express_weight=config.express_weight,
+                    forecast_at_injected=config.steering_forecast_at_injected,
                 )
             else:
                 intervention = randint_intervention(

--- a/tests/odyssey/training/test_steering_phase.py
+++ b/tests/odyssey/training/test_steering_phase.py
@@ -1,5 +1,7 @@
 """Steering phases fire on schedule, pick attributed positions, add two losses."""
 
+from typing import Any
+
 import torch
 from torch import nn
 
@@ -132,3 +134,50 @@ def test_steering_loss_adds_respond_and_express_at_injected_positions() -> None:
     assert (
         comp_none["respond_loss"].item() == 0.0 and comp_none["n_injected"].item() == 0
     )
+
+
+def test_forecast_losses_can_skip_the_injected_positions() -> None:
+    """With ``forecast_at_injected=False`` the forecast is scored off-injection.
+
+    The injected positions still carry respond and express; the
+    next-event loss equals the one computed on a chunk whose real mask
+    excludes them; and when every real position is injected the forecast
+    terms vanish so the total is respond plus express alone.
+    """
+    torch.manual_seed(0)
+    model = _model()
+    model.eval()  # no dropout, so the three forwards below are comparable
+    chunk = _chunk()
+    injected = torch.tensor([[False, True, True, False]])
+    direction = torch.nn.functional.normalize(torch.randn(HIDDEN), dim=0)
+    common: dict[str, Any] = {
+        "state": None,
+        "concept_index": 1,
+        "direction": direction,
+        "gamma": 1.0,
+        "layer_index": 0,
+        "lifted_ids": torch.tensor([4, 6]),
+    }
+    _, on, _ = model.compute_steering_loss(chunk, injected=injected, **common)
+    _, off, _ = model.compute_steering_loss(
+        chunk, injected=injected, forecast_at_injected=False, **common
+    )
+    assert off["n_injected"].item() == on["n_injected"].item() == 2
+    assert torch.isclose(off["respond_loss"], on["respond_loss"])
+    assert torch.isclose(off["express_loss"], on["express_loss"])
+    assert not torch.isclose(off["task_loss"], on["task_loss"])
+    # The same forward scored on a chunk that hides the injected positions.
+    hidden = chunk._replace(real_mask=chunk.real_mask & ~injected)
+    _, hidden_comp, _ = model.compute_steering_loss(
+        hidden, injected=injected, forecast_at_injected=False, **common
+    )
+    assert torch.isclose(hidden_comp["task_loss"], off["task_loss"])
+
+    everywhere = chunk.real_mask.clone()
+    total, comp, _ = model.compute_steering_loss(
+        chunk, injected=everywhere, forecast_at_injected=False, **common
+    )
+    assert comp["task_loss"].item() == 0.0 and comp["time_loss"].item() == 0.0
+    assert torch.isclose(total, comp["respond_loss"] + comp["express_loss"])
+    total.backward()
+    assert model.bottleneck.known_proj.weight.grad is not None


### PR DESCRIPTION
## Why

Both steering-training runs (eICU respond-only, MIMIC respond+express) weakened every dial toward no change while readout and hazard AUROC improved. Reviewing the phase against Steerling Sec. 10.2.4 (Eqs. 18, 19, 31-33, Fig. 30): the equations, weights, schedule and injection site are implemented as written. The mismatch is structural. Our injected positions are the running-label positions, where the concept has already triggered, so the push adds nothing the input does not already carry, and the forecast targets there are unchanged. Scoring the next-event, time, hazard and value losses under injection at those positions trains the network that the push changes nothing. Steerling does not hit this because at its attributed tokens the main loss itself targets concept-expressing tokens; our hazard heads, which the dial benchmark reads, get no push-dependent target at all.

## What

- `compute_steering_loss(..., forecast_at_injected=True)`: with `False`, the forecasting losses are scored on the real positions that were not injected (both the real mask and the targets are masked, since the plain next-token path scores every non-padding target), and the injected positions carry respond and express only.
- `TrainingConfig.steering_forecast_at_injected` (default `True`, the recipe as written) plumbs it through.
- Test: respond/express unchanged by the flag, task loss equals the one on a chunk with the injected positions hidden, and with every real position injected the forecast terms vanish and the total is respond + express.

Default behaviour is unchanged. The eICU steer2 rerun will use `steering_forecast_at_injected: false` with `steering_tau: 1.0` (training pushed at fixed gamma 1 while the benchmark pushes at tau-calibrated 1.06-2.38), followed by a control epoch with `steering_phases: 0` to separate steering training from one extra epoch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KocCJujRUmyVvuoh5ushFU