### PR TITLE
GEMINI eval export: whitelist the value-head and set-level aggregates

### DIFF
--- a/scripts/gemini/run.sh
+++ b/scripts/gemini/run.sh
@@ -1184,12 +1184,16 @@ import sys
 
 # Mirrors odyssey/inference/run_inference.py's InferenceResults/
 # odyssey/training/metrics.py's TaskMetrics/ConceptMetrics/
-# ObservabilityMetrics/TimeMetrics dataclasses exactly -- keep in sync by
+# ObservabilityMetrics/TimeMetrics/ValueMetrics dataclasses exactly -- keep in sync by
 # hand if those ever gain a field; the whole point of a whitelist is that
 # an unrecognized field refuses instead of silently passing through.
 TASK_METRICS_KEYS = {
     "cross_entropy", "perplexity", "top1_accuracy", "top5_accuracy",
-    "n_predictions", "set_top1_accuracy",
+    "n_predictions", "set_top1_accuracy", "n_set_predictions",
+    "category_set_top1_accuracy", "n_category_predictions",
+}
+VALUE_METRICS_KEYS = {
+    "crps", "n_positions", "coverage", "median_absolute_error", "by_signal",
 }
 CONCEPT_METRICS_KEYS = {
     "name", "n_observed", "prevalence", "auroc", "auprc",
@@ -1206,7 +1210,7 @@ CALIBRATION_ENTRY_KEYS = {"predicted", "observed"}
 TOP_LEVEL_KEYS = {
     "task_metrics", "task_metrics_by_code_type", "concept_metrics",
     "observability_metrics", "orthogonality", "n_patient_ends_scored",
-    "time_metrics", "tail_slice",
+    "time_metrics", "value_metrics", "tail_slice",
 }
 
 
@@ -1249,9 +1253,31 @@ def _check_time_metrics(obj, label):
     )
 
 
+def _check_value_metrics(obj, label, nested=False):
+    # ValueMetrics: aggregate CRPS / coverage-by-quantile-level / MAE, with
+    # by_signal one level deep keyed by curated panel signal name.
+    if obj is None:
+        return
+    _check_no_extra_keys(obj, VALUE_METRICS_KEYS, label)
+    coverage = obj.get("coverage")
+    if coverage is not None:
+        _require_dict(coverage, f"{label}.coverage")
+        for level, value in coverage.items():
+            if not isinstance(value, (int, float)):
+                raise ValueError(f"{label}.coverage[{level!r}]: expected a number")
+    by_signal = obj.get("by_signal")
+    if by_signal:
+        if nested:
+            raise ValueError(f"{label}.by_signal: must be empty one level down")
+        _require_dict(by_signal, f"{label}.by_signal")
+        for signal, entry in by_signal.items():
+            _check_value_metrics(entry, f"{label}.by_signal[{signal!r}]", nested=True)
+
+
 def validate(obj, label="root"):
     _check_no_extra_keys(obj, TOP_LEVEL_KEYS, label)
     _check_task_metrics(obj.get("task_metrics"), f"{label}.task_metrics")
+    _check_value_metrics(obj.get("value_metrics"), f"{label}.value_metrics")
 
     by_code_type = obj.get("task_metrics_by_code_type")
     if by_code_type is not None:

--- a/tests/scripts/gemini/test_run_sh_eval_export.py
+++ b/tests/scripts/gemini/test_run_sh_eval_export.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import pytest
 
+
 REPO = Path(__file__).resolve().parents[3]
 RUN_SH = REPO / "scripts" / "gemini" / "run.sh"
 BANKED = (

--- a/tests/scripts/gemini/test_run_sh_eval_export.py
+++ b/tests/scripts/gemini/test_run_sh_eval_export.py
@@ -47,7 +47,7 @@ def _validate(obj: dict) -> None:
 
 
 def _eval_shape() -> dict:
-    """What run_inference writes today: every InferenceResults field set."""
+    """Build the shape run_inference writes today: every InferenceResults field set."""
     value = {
         "crps": 0.31,
         "n_positions": 12345,

--- a/tests/scripts/gemini/test_run_sh_eval_export.py
+++ b/tests/scripts/gemini/test_run_sh_eval_export.py
@@ -1,0 +1,101 @@
+"""The eval-export whitelist accepts every aggregate field the eval writes.
+
+Regression guard for 2026-09-02: ``eval-forecast gemini_full_DEC_v12``
+ran to completion on the H200 and then refused to export its own
+summary, because ``value_metrics`` and the set-level task accuracies
+were added to ``InferenceResults`` after the whitelist was written. The
+whitelist must refuse anything unknown (that is its job: nothing
+per-patient leaves GEMINI), so this test runs the shipped validator, not
+a copy of it, on the exact shape ``run_inference`` writes.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[3]
+RUN_SH = REPO / "scripts" / "gemini" / "run.sh"
+BANKED = (
+    REPO
+    / "research_journal"
+    / "figure_data"
+    / "vm1"
+    / "full_run_DEC_v12"
+    / "inference_results.json"
+)
+
+
+def _validator_source() -> str:
+    source = RUN_SH.read_text()
+    match = re.search(
+        r"python3 - \"\$source_json\" <<'PY'\n(.*?)\nPY\n", source, re.DOTALL
+    )
+    assert match, "export validator heredoc not found in run.sh"
+    body = match.group(1)
+    assert "TASK_METRICS_KEYS" in body
+    # Drop the script's argv/file tail; we call validate() directly.
+    return body.split("source_path = sys.argv[1]", 1)[0]
+
+
+def _validate(obj: dict) -> None:
+    namespace: dict = {}
+    exec(_validator_source(), namespace)  # noqa: S102 - the shipped validator
+    namespace["validate"](obj)
+
+
+def _eval_shape() -> dict:
+    """What run_inference writes today: every InferenceResults field set."""
+    value = {
+        "crps": 0.31,
+        "n_positions": 12345,
+        "coverage": {"0.1": 0.11, "0.5": 0.49, "0.9": 0.88},
+        "median_absolute_error": 0.42,
+        "by_signal": {},
+    }
+    return {
+        "task_metrics": {
+            "cross_entropy": 1.9,
+            "perplexity": 6.7,
+            "top1_accuracy": 0.55,
+            "top5_accuracy": 0.8,
+            "n_predictions": 1000,
+            "set_top1_accuracy": 0.8,
+            "n_set_predictions": 999,
+            "category_set_top1_accuracy": 0.49,
+            "n_category_predictions": 500,
+        },
+        "task_metrics_by_code_type": {},
+        "concept_metrics": [],
+        "observability_metrics": [],
+        "orthogonality": None,
+        "n_patient_ends_scored": 100,
+        "time_metrics": None,
+        "value_metrics": dict(value, by_signal={"creatinine": value}),
+        "tail_slice": None,
+    }
+
+
+def test_current_eval_shape_exports() -> None:
+    _validate(_eval_shape())
+
+
+@pytest.mark.skipif(not BANKED.exists(), reason="banked eval JSON not present")
+def test_a_banked_full_eval_exports() -> None:
+    _validate(json.loads(BANKED.read_text()))
+
+
+def test_unknown_keys_still_refuse() -> None:
+    shape = _eval_shape()
+    shape["per_subject_scores"] = [1, 2, 3]
+    with pytest.raises(ValueError, match="per_subject_scores"):
+        _validate(shape)
+    shape = _eval_shape()
+    shape["value_metrics"]["subject_ids"] = [1]
+    with pytest.raises(ValueError, match="subject_ids"):
+        _validate(shape)
+    shape = _eval_shape()
+    shape["value_metrics"]["by_signal"]["creatinine"]["by_signal"] = {"x": {}}
+    with pytest.raises(ValueError, match="one level down"):
+        _validate(shape)


### PR DESCRIPTION
## Why

`scripts/gemini/run.sh eval-forecast gemini_full_DEC_v12` ran the full held-out set on the H200 and then refused to export its own summary:

```
REFUSING to export: root: unexpected key(s) ['value_metrics'] -- not in the known aggregate-metric whitelist
REFUSING to export: root.task_metrics: unexpected key(s) ['category_set_top1_accuracy', 'n_category_predictions', 'n_set_predictions']
```

Those fields were added to `InferenceResults` / `TaskMetrics` after the whitelist was written. They are aggregates: CRPS, per-quantile-level coverage, median absolute error and a position count, with `by_signal` keyed by curated panel signal one level deep; and three set-level accuracies/counts.

## What

- `TASK_METRICS_KEYS` gains the three set-level keys; `TOP_LEVEL_KEYS` gains `value_metrics`; a `_check_value_metrics` validates the ValueMetrics shape (numbers under `coverage`, `by_signal` entries validated with the same key set and required empty one level down).
- `tests/scripts/gemini/test_run_sh_eval_export.py` extracts the shipped validator from run.sh and runs it on the exact shape `run_inference` writes today, and checks that unknown keys (a per-subject list, an id list inside value_metrics, a nested by_signal) still refuse.

Nothing per-patient is admitted; the whitelist stays a whitelist. After merge the GEMINI mirror needs a sync; the next run.sh step's backfill then exports `gemini_full_DEC_v12_eval_forecast.json` (and the two older summaries it also skipped) without re-running the eval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KocCJujRUmyVvuoh5ushFU