### PR TITLE
Interventions: let a transformer backbone run the label-override test

### DIFF
--- a/odyssey/inference/interventions.py
+++ b/odyssey/inference/interventions.py
@@ -519,12 +519,16 @@ def evaluate_interventions(
             f"{getattr(config, 'model_kind', 'bottleneck')!r}"
         )
     if getattr(config, "backbone", "hybrid") == "transformer":
-        raise NotImplementedError(
-            "interventions is not yet wired for backbone='transformer': this "
-            "is concept-bottleneck-lever tooling, not needed for the backbone "
-            "control's own subset-scale comparison (unlike run_inference and "
-            "alerts, which are). Extend it only if the transformer backbone "
-            "earns longer-term status."
+        # The TBTT stream below is the same one the transformer trained on:
+        # its ``state`` is an inert sentinel and every chunk is its own
+        # context window, so a stateless backbone sees exactly the context
+        # it was optimized for. What differs from run_inference/alerts is
+        # only that those hand the transformer whole-patient context
+        # (PackedContextSampler); the lever test keeps training's view.
+        logger.info(
+            "[interventions] backbone='transformer': chunks of %d tokens are "
+            "independent context windows, as in training",
+            chunk_size,
         )
 
     logger.info("[interventions] loading held-out shards from %s", held_out_shard_dir)

--- a/tests/odyssey/inference/test_interventions.py
+++ b/tests/odyssey/inference/test_interventions.py
@@ -515,16 +515,16 @@ def test_evaluate_interventions_accepts_a_transformer_backbone(
         lambda *a, **k: (fake_model, object(), object(), fake_config),
     )
 
-    class _ReachedShards(Exception):
+    class _ReachedShardsError(Exception):
         pass
 
     def _reached(*_args: object, **_kwargs: object) -> None:
-        raise _ReachedShards
+        raise _ReachedShardsError
 
     monkeypatch.setattr(interventions_module, "load_meds_shards", _reached)
 
     # No backbone gate: the evaluation proceeds to the held-out shards.
-    with pytest.raises(_ReachedShards):
+    with pytest.raises(_ReachedShardsError):
         evaluate_interventions("/runs/x", "/data/held_out")
 
 

--- a/tests/odyssey/inference/test_interventions.py
+++ b/tests/odyssey/inference/test_interventions.py
@@ -456,7 +456,7 @@ def test_run_streaming_intervention_handles_an_unmasked_intervention(
 
 
 # ---------------------------------------------------------------------------
-# evaluate_interventions: backbone="transformer" gate
+# evaluate_interventions: backbone="transformer" streams like training
 # ---------------------------------------------------------------------------
 
 
@@ -487,9 +487,16 @@ def test_evaluate_interventions_rejects_a_non_bottleneck_model(
         evaluate_interventions("/runs/x", "/data/held_out")
 
 
-def test_evaluate_interventions_rejects_transformer_backbone_before_touching_shards(
+def test_evaluate_interventions_accepts_a_transformer_backbone(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """A transformer run streams the lever test like it trained: no gate.
+
+    Until 2026-09-03 this raised NotImplementedError; the full-scale
+    transformer arm (backbone portability of the decomposition) needs the
+    same label-override numbers as the hybrid, and the TBTT stream here is
+    the transformer's own training view (state ignored, chunk = context).
+    """
     fake_model = ConceptBottleneckSequenceModel(
         TinyGRUBackbone(vocab_size=10, hidden_size=4),
         vocab_size=10,
@@ -508,12 +515,16 @@ def test_evaluate_interventions_rejects_transformer_backbone_before_touching_sha
         lambda *a, **k: (fake_model, object(), object(), fake_config),
     )
 
-    def _boom(*_args: object, **_kwargs: object) -> None:
-        raise AssertionError("must not read shards before the backbone gate fires")
+    class _ReachedShards(Exception):
+        pass
 
-    monkeypatch.setattr(interventions_module, "load_meds_shards", _boom)
+    def _reached(*_args: object, **_kwargs: object) -> None:
+        raise _ReachedShards
 
-    with pytest.raises(NotImplementedError, match="backbone='transformer'"):
+    monkeypatch.setattr(interventions_module, "load_meds_shards", _reached)
+
+    # No backbone gate: the evaluation proceeds to the held-out shards.
+    with pytest.raises(_ReachedShards):
         evaluate_interventions("/runs/x", "/data/held_out")
 
 


### PR DESCRIPTION
## Why

`full_run_DEC_v12_tfm` (the decomposition on an 8-layer transformer backbone, the backbone-portability arm) finished training tonight and its eval chain's interventions stage died on the explicit gate:

```
NotImplementedError: interventions is not yet wired for backbone='transformer' ...
```

The gate predates the arm's paper role. The TBTT stream the tool already uses is exactly how the transformer trained (its `state` is an inert sentinel; every chunk is its own context window), so nothing else needs wiring for the lever test. `run_inference` and `alerts` hand the transformer whole-patient context; the lever test keeps training's view, and now logs that.

## What

- `evaluate_interventions`: the gate becomes a log line.
- Test: the transformer-config test now asserts the evaluation proceeds to the held-out shards instead of raising.

The arm's chain is being rerun at 16 lanes (the 64-lane eval stage OOMed on the A100) from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KocCJujRUmyVvuoh5ushFU