### PR TITLE
Alerts: fit the GEMINI GBM on every train shard via seeded row thinning

### DIFF
--- a/odyssey/inference/alerts.py
+++ b/odyssey/inference/alerts.py
@@ -1438,8 +1438,14 @@ def fit_baselines_streaming(
     tune: bool = True,
     task_set: str = "v1",
     index_mode: str = "landmark",
+    row_fraction: float = 1.0,
 ) -> dict[tuple[str, float], BaselineModel]:
     """Fit the same models as :func:`fit_baselines`, but shard by shard.
+
+    ``row_fraction`` thins each shard's landmark rows before the per-cell
+    row cap (see :func:`stream_baseline_matrix`), so the GBM can be fitted
+    on a sample of EVERY train shard when the full matrix would not fit in
+    memory; the cap then draws its million rows from all of them.
 
     The full-scale baseline shard set (hundreds of shards, hundreds of
     millions of events) does not fit in memory as one frame -- the same
@@ -1466,6 +1472,8 @@ def fit_baselines_streaming(
         feature_set=feature_set,
         task_set=task_set,
         index_mode=index_mode,
+        row_fraction=row_fraction,
+        seed=seed,
     )
     models: dict[tuple[str, float], BaselineModel] = {}
     if not all_rows:
@@ -2433,6 +2441,7 @@ def _fit_and_score_gbm_baselines(
     task_set: str = "v1",
     index_mode: str = "landmark",
     prefit_baselines: dict[tuple[str, float], BaselineModel] | None = None,
+    baseline_row_fraction: float = 1.0,
 ) -> tuple[dict[tuple[str, float], BaselineModel] | None, dict[str, np.ndarray] | None]:
     """Fit and score the GBM baselines for one alerts pass.
 
@@ -2480,8 +2489,11 @@ def _fit_and_score_gbm_baselines(
             tune=tune_baselines,
             task_set=task_set,
             index_mode=index_mode,
+            row_fraction=baseline_row_fraction,
         )
     else:
+        if baseline_row_fraction < 1.0:
+            raise ValueError("--baseline-row-fraction needs --stream-baseline-shards")
         logger.info("[alerts] fitting GBM baselines on %s", baseline_shard_dir)
         train_raw = _load_prepared_raw(
             baseline_shard_dir, max_baseline_shards, config, source
@@ -2607,6 +2619,7 @@ def evaluate_alerts(  # noqa: PLR0912, PLR0915
     index_mode: str = "landmark",
     unscoreable_out: set[tuple[int, int, float]] | None = None,
     zero_channel: str | None = None,
+    baseline_row_fraction: float = 1.0,
 ) -> list[AlertMetrics]:
     """End to end: model scores + optional GBM baselines, scored on held-out.
 
@@ -2794,6 +2807,7 @@ def evaluate_alerts(  # noqa: PLR0912, PLR0915
         task_set=task_set,
         index_mode=index_mode,
         prefit_baselines=prefit_baselines,
+        baseline_row_fraction=baseline_row_fraction,
     )
     if fitted_baselines_out is not None and baselines is not None:
         fitted_baselines_out.update(baselines)
@@ -2861,6 +2875,14 @@ def _main() -> None:
     )
     parser.add_argument("--max-shards", type=int, default=None)
     parser.add_argument("--max-baseline-shards", type=int, default=None)
+    parser.add_argument(
+        "--baseline-row-fraction",
+        type=float,
+        default=1.0,
+        help="with --stream-baseline-shards: keep this seeded fraction of each train "
+        "shard's landmark rows before the per-cell row cap, so the GBM can be fitted "
+        "on a sample of every train shard (the cap still draws 1M rows per cell)",
+    )
     parser.add_argument("--landmark-hours", type=float, default=4.0)
     parser.add_argument(
         "--index-mode",
@@ -2978,6 +3000,7 @@ def _main() -> None:
         stream_baseline=args.stream_baseline_shards,
         dump_rows_path=args.dump_rows,
         zero_channel=args.zero_channel,
+        baseline_row_fraction=args.baseline_row_fraction,
     )
     out.parent.mkdir(parents=True, exist_ok=True)
     # Per-record field, not a top-level wrapper: build_alert_finding (and

--- a/scripts/gemini/run.sh
+++ b/scripts/gemini/run.sh
@@ -1532,16 +1532,22 @@ PY
         # shards, TabICL 4), n differed 8.8x, and the two could never share a
         # table -- see tab:tabicl's separate existence. One knob feeds both.
         local alert_shards="${GEMINI_ALERT_SHARDS:-4}"
-        local baseline_shards="${GEMINI_BASELINE_SHARDS:-30}"
+        local baseline_shards="${GEMINI_BASELINE_SHARDS:-1000}"
+        local baseline_row_fraction="${GEMINI_BASELINE_ROW_FRACTION:-0.1}"
+        local alerts_tag="${GEMINI_ALERTS_TAG:-}"
         local num_lanes="${GEMINI_EVAL_NUM_LANES:-16}"
         local chunk="${GEMINI_EVAL_CHUNK:-512}"
         local checkpoint="${GEMINI_ALERT_CHECKPOINT:-checkpoint_best.pt}"
 
         echo "=== alerts ($run_name) ==="
         echo "Hazard heads vs the strong tuned per-event GBM on the landmark rows."
-        echo "alert_shards=$alert_shards (held-out), baseline_shards=$baseline_shards (train),"
+        echo "alert_shards=$alert_shards (held-out), baseline_shards=$baseline_shards (train,"
+        echo "1000 = every shard), baseline_row_fraction=$baseline_row_fraction (seeded thinning"
+        echo "of each train shard's landmark rows before the 1M-row per-cell cap: the MIMIC-IV"
+        echo "and eICU GBMs were fitted on every train shard and GEMINI's must be too),"
         echo "num_lanes=$num_lanes, chunk=$chunk, checkpoint=$checkpoint."
-        echo "Override via GEMINI_ALERT_SHARDS / GEMINI_BASELINE_SHARDS /"
+        echo "Override via GEMINI_ALERT_SHARDS / GEMINI_BASELINE_SHARDS / GEMINI_BASELINE_ROW_FRACTION /"
+        echo "GEMINI_ALERTS_TAG (suffix for alerts<tag>.json, to keep an earlier pass) /"
         echo "GEMINI_EVAL_NUM_LANES / GEMINI_EVAL_CHUNK / GEMINI_ALERT_CHECKPOINT."
         if [[ -z "${TMUX:-}" && -z "${STY:-}" ]]; then
             echo "WARNING: this doesn't look like a tmux or screen session --" >&2
@@ -1574,8 +1580,8 @@ PY
             fi
         done
 
-        OUTPUT_JSON="$RUN_DIR/alerts.json"
-        DUMP_ROWS="$RUN_DIR/alerts_rows.parquet"
+        OUTPUT_JSON="$RUN_DIR/alerts${alerts_tag}.json"
+        DUMP_ROWS="$RUN_DIR/alerts_rows${alerts_tag}.parquet"
         echo "Run dir: $RUN_DIR"
         echo "Held-out: $HELD_OUT_SHARD_DIR"
         echo "Train (GBM fit): $TRAIN_SHARD_DIR"
@@ -1597,13 +1603,14 @@ PY
             --output-json "$OUTPUT_JSON" \
             --dump-rows "$DUMP_ROWS" \
             --checkpoint "$checkpoint" \
+            --baseline-row-fraction "$baseline_row_fraction" \
             --stream-baseline-shards
         deactivate
         source "$VENV/bin/activate"
 
         echo "$STEP complete. Results at $OUTPUT_JSON"
 
-        if ! _export_alerts_summary "$run_name" "$OUTPUT_JSON"; then
+        if ! _export_alerts_summary "$run_name$alerts_tag" "$OUTPUT_JSON"; then
             echo "WARNING: this run's alerts summary was not exported (see above)." >&2
         fi
     }

--- a/tests/odyssey/inference/test_alerts.py
+++ b/tests/odyssey/inference/test_alerts.py
@@ -2495,3 +2495,36 @@ def test_stream_baseline_matrix_row_fraction_thins_deterministically(
             feature_set="basic",
             row_fraction=0.0,
         )
+
+
+def test_fit_baselines_streaming_row_fraction_fits_on_a_thinned_matrix(
+    tmp_path: Path,
+) -> None:
+    """The GBM fits from a seeded fraction of every shard's rows (GEMINI scale)."""
+    shard_dir = tmp_path / "train"
+    _write_event_shards(shard_dir, n_shards=3, subjects_per_shard=20)
+    paths = shard_paths(shard_dir)
+    prepare = make_preparer(
+        normalize_medications=False, history_recap=False, source="mimic_iv"
+    )
+    models = fit_baselines_streaming(
+        paths,
+        prepare,
+        None,
+        alerts=ALERT_EVENTS,
+        feature_set="basic",
+        tune=False,
+        row_fraction=0.6,
+    )
+    assert models, "no cell had enough rows after thinning"
+    for model in models.values():
+        assert model.n_features > 0
+    with pytest.raises(ValueError, match="row_fraction"):
+        fit_baselines_streaming(
+            paths,
+            prepare,
+            None,
+            alerts=ALERT_EVENTS,
+            feature_set="basic",
+            row_fraction=1.5,
+        )


### PR DESCRIPTION
## Why

Reviewer C10 / Amrit: is the GEMINI comparison fair? The MIMIC-IV and eICU GBMs in Tables 5 and 6 were fitted on every train shard (verified: the all-shard refit in the feature-group ablation reproduces Table 5's GBM exactly, a 30-shard refit does not; eICU's chain set BASELINE_SHARDS=134). GEMINI's was fitted on 100 of 894 shards because the streaming fit materializes every landmark row of every shard before the per-cell 1M-row cap, and 894 shards would be ~50M rows x 609 features.

## What

- `odyssey.inference.alerts --baseline-row-fraction f` (requires `--stream-baseline-shards`): plumbs the seeded, key-based per-shard row thinning added in #229 (`stream_baseline_matrix(row_fraction=...)`) into `fit_baselines_streaming`, so the GBM sees a sample of every train shard's patients at a bounded matrix size; the per-cell cap then draws its million rows from all of them.
- `scripts/gemini/run.sh alerts`: `GEMINI_BASELINE_SHARDS` now defaults to every shard (1000), `GEMINI_BASELINE_ROW_FRACTION` defaults to 0.1, and `GEMINI_ALERTS_TAG` suffixes the output/dump/export names so a rerun does not clobber the earlier pass.
- Test: the streaming fit works from a thinned matrix and rejects a fraction outside (0, 1].

After merge and mirror sync, the GEMINI rerun is:
```
GEMINI_ALERT_SHARDS=1000 GEMINI_ALERTS_TAG=_allshards scripts/gemini/run.sh alerts gemini_full_DEC_v12
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KocCJujRUmyVvuoh5ushFU