### PR TITLE
Long-history comparison: two backbones on the same rows, split by history length

### DIFF
--- a/scripts/long_history_compare.py
+++ b/scripts/long_history_compare.py
@@ -1,20 +1,20 @@
-"""Does unbounded history help? Two backbones on the same rows, split by history length.
+"""Does unbounded history help? Two backbones on the same rows, split by truncation.
 
 The hybrid backbone streams a record of any length at constant memory per
-step; a transformer sees at most ``--window`` tokens (its packed-context
-evaluation keeps the most recent ones). Both models' alert dumps
-(``alerts_rows.parquet``) are joined on (subject, visit, time, event), each
-row is tagged with how many events the patient had accumulated by that
-landmark, and the hazard heads' AUROC is compared per (event, horizon) on
-two strata: rows within the window (both backbones saw the whole history)
-and rows beyond it (only the hybrid did). A paired subject-clustered
-bootstrap of the AUROC difference is reported per cell and stratum. If the
-streaming property matters, the difference should appear in the long
-stratum and not in the short one.
+step; the transformer's packed-context evaluation keeps each subject's most
+recent ``max_context`` tokens, so a long record is scored only inside that
+tail window, with the window's start as the model's first visible token.
+Both models' alert dumps (``alerts_rows.parquet``) are joined on (subject,
+visit, time, event) and every subject is tagged from the dumps themselves:
+``truncated`` if the transformer's first scored row comes later than the
+hybrid's (the transformer never saw the record's start), else ``whole``.
+The hazard heads' AUROC is compared per (event, horizon) on the two strata
+with a paired subject-clustered bootstrap of the difference.
 
-History length is the number of timed events with time <= the landmark,
-counted from the held-out MEDS shards in the same hours-since-origin
-frame the dumps use; one token per event, so it is the token position.
+Read the truncated stratum with care: every one of its rows lies within
+``max_context`` tokens of the record's end, and a transformer trained with
+the same end-anchored truncation can read time-to-end off its position in
+the window. Only the whole stratum is a clean backbone comparison.
 
 Usage::
 
@@ -22,7 +22,6 @@ Usage::
         --dump-a ~/runs/full_run_DEC_v12/alerts_rows.parquet --label-a hybrid \\
         --dump-b ~/runs/full_run_DEC_v12_tfm/alerts_rows.parquet \\
         --label-b transformer \\
-        --held-out-shard-dir ~/data/mimiciv_3.1_v1/data/held_out --window 2048 \\
         --output-json ~/runs/full_run_DEC_v12_tfm/long_history_compare.json
 """
 
@@ -39,9 +38,7 @@ import numpy as np
 import polars as pl
 from sklearn.metrics import roc_auc_score
 
-from odyssey.data.alert_events import hours_since_origin, origin_hours
 from odyssey.inference.uncertainty import bootstrap_auroc_delta
-from odyssey.training.data import load_meds_shards
 
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
@@ -50,33 +47,13 @@ logger = logging.getLogger("long_history_compare")
 KEY = ["subject_id", "visit_id", "time_hours", "event"]
 
 
-def history_lengths(events: pl.DataFrame) -> dict[int, np.ndarray]:
-    """Per subject, the sorted hours-since-origin of every timed event.
-
-    ``events`` is a raw MEDS frame (``subject_id``, ``time``, ``code``);
-    the origin is each subject's first timed non-birth event, as in the
-    alerts protocol, so a dump's ``time_hours`` is on the same axis.
-    """
-    origins = origin_hours(events)
-    timed = events.filter(pl.col("time").is_not_null())
-    hours = hours_since_origin(timed, "time", origins).select("subject_id", "time")
-    out: dict[int, np.ndarray] = {}
-    for sid, group in hours.group_by("subject_id"):
-        key = int(sid[0]) if isinstance(sid, tuple) else int(sid)
-        out[key] = np.sort(group["time"].to_numpy().astype(float))
-    return out
-
-
-def tag_history(frame: pl.DataFrame, lengths: dict[int, np.ndarray]) -> pl.DataFrame:
-    """Add ``history_len``: events accumulated by each row's landmark time."""
-    subjects = frame["subject_id"].to_numpy().astype(int)
-    times = frame["time_hours"].to_numpy().astype(float)
-    counts = np.zeros(len(frame), dtype=np.int64)
-    for sid in np.unique(subjects):
-        mask = subjects == sid
-        t = lengths.get(int(sid))
-        counts[mask] = 0 if t is None else np.searchsorted(t, times[mask], side="right")
-    return frame.with_columns(pl.Series("history_len", counts))
+def tag_truncation(a: pl.DataFrame, b: pl.DataFrame) -> pl.DataFrame:
+    """Per subject, ``truncated`` = dump b's first scored row is later than dump a's."""
+    first_a = a.group_by("subject_id").agg(pl.col("time_hours").min().alias("_a0"))
+    first_b = b.group_by("subject_id").agg(pl.col("time_hours").min().alias("_b0"))
+    return first_a.join(first_b, on="subject_id", how="inner").select(
+        "subject_id", (pl.col("_b0") > pl.col("_a0")).alias("truncated")
+    )
 
 
 def join_dumps(
@@ -97,7 +74,6 @@ def compare(
     *,
     label_a: str,
     label_b: str,
-    window: int,
     n_boot: int,
     seed: int,
 ) -> list[dict[str, Any]]:
@@ -109,8 +85,8 @@ def compare(
     for event in sorted(joined["event"].unique().to_list()):
         for h in horizons:
             for stratum, cond in (
-                ("within_window", pl.col("history_len") <= window),
-                ("beyond_window", pl.col("history_len") > window),
+                ("whole", ~pl.col("truncated")),
+                ("truncated", pl.col("truncated")),
             ):
                 sub = joined.filter(
                     (pl.col("event") == event) & cond & pl.col(f"y@{h}").is_not_null()
@@ -141,7 +117,7 @@ def compare(
 
 
 def main() -> None:
-    """Join the two dumps, tag history length, and write the stratified comparison."""
+    """Join the two dumps, tag truncation, and write the stratified comparison."""
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
@@ -149,8 +125,6 @@ def main() -> None:
     parser.add_argument("--label-a", default="hybrid")
     parser.add_argument("--dump-b", required=True, type=Path)
     parser.add_argument("--label-b", default="transformer")
-    parser.add_argument("--held-out-shard-dir", required=True)
-    parser.add_argument("--window", type=int, default=2048)
     parser.add_argument("--n-boot", type=int, default=1000)
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--output-json", required=True, type=Path)
@@ -162,19 +136,21 @@ def main() -> None:
     logger.info(
         "dump a %d rows, dump b %d rows, joined %d", a.height, b.height, joined.height
     )
-    events = load_meds_shards(args.held_out_shard_dir)
-    lengths = history_lengths(events)
-    del events
-    joined = tag_history(joined, lengths)
-    beyond = int((joined["history_len"] > args.window).sum())
+    tags = tag_truncation(a, b)
+    joined = joined.join(tags, on="subject_id", how="inner")
+    n_trunc = int(tags["truncated"].sum())
+    rows_trunc = int(joined["truncated"].sum())
     logger.info(
-        "rows beyond the %d-token window: %d of %d", args.window, beyond, joined.height
+        "truncated subjects: %d of %d (%d of %d joined rows)",
+        n_trunc,
+        tags.height,
+        rows_trunc,
+        joined.height,
     )
     cells = compare(
         joined,
         label_a=args.label_a,
         label_b=args.label_b,
-        window=args.window,
         n_boot=args.n_boot,
         seed=args.seed,
     )
@@ -198,9 +174,10 @@ def main() -> None:
         "label_a": args.label_a,
         "dump_b": str(args.dump_b),
         "label_b": args.label_b,
-        "window": args.window,
+        "n_subjects": int(tags.height),
+        "n_truncated_subjects": n_trunc,
         "n_joined_rows": int(joined.height),
-        "n_beyond_window": beyond,
+        "n_truncated_rows": rows_trunc,
         "n_boot": args.n_boot,
         "seed": args.seed,
         "cells": cells,

--- a/scripts/long_history_compare.py
+++ b/scripts/long_history_compare.py
@@ -1,0 +1,213 @@
+"""Does unbounded history help? Two backbones on the same rows, split by history length.
+
+The hybrid backbone streams a record of any length at constant memory per
+step; a transformer sees at most ``--window`` tokens (its packed-context
+evaluation keeps the most recent ones). Both models' alert dumps
+(``alerts_rows.parquet``) are joined on (subject, visit, time, event), each
+row is tagged with how many events the patient had accumulated by that
+landmark, and the hazard heads' AUROC is compared per (event, horizon) on
+two strata: rows within the window (both backbones saw the whole history)
+and rows beyond it (only the hybrid did). A paired subject-clustered
+bootstrap of the AUROC difference is reported per cell and stratum. If the
+streaming property matters, the difference should appear in the long
+stratum and not in the short one.
+
+History length is the number of timed events with time <= the landmark,
+counted from the held-out MEDS shards in the same hours-since-origin
+frame the dumps use; one token per event, so it is the token position.
+
+Usage::
+
+    uv run python scripts/long_history_compare.py \\
+        --dump-a ~/runs/full_run_DEC_v12/alerts_rows.parquet --label-a hybrid \\
+        --dump-b ~/runs/full_run_DEC_v12_tfm/alerts_rows.parquet \\
+        --label-b transformer \\
+        --held-out-shard-dir ~/data/mimiciv_3.1_v1/data/held_out --window 2048 \\
+        --output-json ~/runs/full_run_DEC_v12_tfm/long_history_compare.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import polars as pl
+from sklearn.metrics import roc_auc_score
+
+from odyssey.data.alert_events import hours_since_origin, origin_hours
+from odyssey.inference.uncertainty import bootstrap_auroc_delta
+from odyssey.training.data import load_meds_shards
+
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("long_history_compare")
+
+KEY = ["subject_id", "visit_id", "time_hours", "event"]
+
+
+def history_lengths(events: pl.DataFrame) -> dict[int, np.ndarray]:
+    """Per subject, the sorted hours-since-origin of every timed event.
+
+    ``events`` is a raw MEDS frame (``subject_id``, ``time``, ``code``);
+    the origin is each subject's first timed non-birth event, as in the
+    alerts protocol, so a dump's ``time_hours`` is on the same axis.
+    """
+    origins = origin_hours(events)
+    timed = events.filter(pl.col("time").is_not_null())
+    hours = hours_since_origin(timed, "time", origins).select("subject_id", "time")
+    out: dict[int, np.ndarray] = {}
+    for sid, group in hours.group_by("subject_id"):
+        key = int(sid[0]) if isinstance(sid, tuple) else int(sid)
+        out[key] = np.sort(group["time"].to_numpy().astype(float))
+    return out
+
+
+def tag_history(frame: pl.DataFrame, lengths: dict[int, np.ndarray]) -> pl.DataFrame:
+    """Add ``history_len``: events accumulated by each row's landmark time."""
+    subjects = frame["subject_id"].to_numpy().astype(int)
+    times = frame["time_hours"].to_numpy().astype(float)
+    counts = np.zeros(len(frame), dtype=np.int64)
+    for sid in np.unique(subjects):
+        mask = subjects == sid
+        t = lengths.get(int(sid))
+        counts[mask] = 0 if t is None else np.searchsorted(t, times[mask], side="right")
+    return frame.with_columns(pl.Series("history_len", counts))
+
+
+def join_dumps(
+    a: pl.DataFrame, b: pl.DataFrame, label_a: str, label_b: str
+) -> pl.DataFrame:
+    """Inner-join two dumps on the row key, keeping y@h and each model's hazard@h."""
+    horizons = sorted({c.split("@")[1] for c in a.columns if c.startswith("hazard@")})
+    keep = KEY + [f"y@{h}" for h in horizons] + [f"hazard@{h}" for h in horizons]
+    ra = a.select(keep).rename({f"hazard@{h}": f"{label_a}@{h}" for h in horizons})
+    rb = b.select(KEY + [f"hazard@{h}" for h in horizons]).rename(
+        {f"hazard@{h}": f"{label_b}@{h}" for h in horizons}
+    )
+    return ra.join(rb, on=KEY, how="inner")
+
+
+def compare(
+    joined: pl.DataFrame,
+    *,
+    label_a: str,
+    label_b: str,
+    window: int,
+    n_boot: int,
+    seed: int,
+) -> list[dict[str, Any]]:
+    """Per (event, horizon, stratum): both AUROCs and the paired delta a - b."""
+    horizons = sorted(
+        {c.split("@")[1] for c in joined.columns if c.startswith(f"{label_a}@")}
+    )
+    cells: list[dict[str, Any]] = []
+    for event in sorted(joined["event"].unique().to_list()):
+        for h in horizons:
+            for stratum, cond in (
+                ("within_window", pl.col("history_len") <= window),
+                ("beyond_window", pl.col("history_len") > window),
+            ):
+                sub = joined.filter(
+                    (pl.col("event") == event) & cond & pl.col(f"y@{h}").is_not_null()
+                )
+                y = sub[f"y@{h}"].to_numpy().astype(int)
+                if len(y) < 50 or y.min() == y.max():
+                    continue
+                pa = sub[f"{label_a}@{h}"].to_numpy().astype(float)
+                pb = sub[f"{label_b}@{h}"].to_numpy().astype(float)
+                sids = sub["subject_id"].to_numpy().astype(int)
+                delta = bootstrap_auroc_delta(y, pa, pb, sids, n_boot=n_boot, seed=seed)
+                cells.append(
+                    {
+                        "event": event,
+                        "horizon": h,
+                        "stratum": stratum,
+                        "n_rows": int(len(y)),
+                        "n_subjects": int(len(np.unique(sids))),
+                        "n_positive": int(y.sum()),
+                        f"auroc_{label_a}": float(roc_auc_score(y, pa)),
+                        f"auroc_{label_b}": float(roc_auc_score(y, pb)),
+                        "delta_a_minus_b": None
+                        if delta is None
+                        else dataclasses.asdict(delta),
+                    }
+                )
+    return cells
+
+
+def main() -> None:
+    """Join the two dumps, tag history length, and write the stratified comparison."""
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--dump-a", required=True, type=Path)
+    parser.add_argument("--label-a", default="hybrid")
+    parser.add_argument("--dump-b", required=True, type=Path)
+    parser.add_argument("--label-b", default="transformer")
+    parser.add_argument("--held-out-shard-dir", required=True)
+    parser.add_argument("--window", type=int, default=2048)
+    parser.add_argument("--n-boot", type=int, default=1000)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--output-json", required=True, type=Path)
+    args = parser.parse_args()
+
+    a = pl.read_parquet(args.dump_a)
+    b = pl.read_parquet(args.dump_b)
+    joined = join_dumps(a, b, args.label_a, args.label_b)
+    logger.info(
+        "dump a %d rows, dump b %d rows, joined %d", a.height, b.height, joined.height
+    )
+    events = load_meds_shards(args.held_out_shard_dir)
+    lengths = history_lengths(events)
+    del events
+    joined = tag_history(joined, lengths)
+    beyond = int((joined["history_len"] > args.window).sum())
+    logger.info(
+        "rows beyond the %d-token window: %d of %d", args.window, beyond, joined.height
+    )
+    cells = compare(
+        joined,
+        label_a=args.label_a,
+        label_b=args.label_b,
+        window=args.window,
+        n_boot=args.n_boot,
+        seed=args.seed,
+    )
+    for c in cells:
+        d = c["delta_a_minus_b"] or {}
+        logger.info(
+            "%s@%s %s: %s %.3f vs %s %.3f, delta %s (n %d, pos %d)",
+            c["event"],
+            c["horizon"],
+            c["stratum"],
+            args.label_a,
+            c[f"auroc_{args.label_a}"],
+            args.label_b,
+            c[f"auroc_{args.label_b}"],
+            {k: round(v, 4) for k, v in d.items() if isinstance(v, float)},
+            c["n_rows"],
+            c["n_positive"],
+        )
+    out = {
+        "dump_a": str(args.dump_a),
+        "label_a": args.label_a,
+        "dump_b": str(args.dump_b),
+        "label_b": args.label_b,
+        "window": args.window,
+        "n_joined_rows": int(joined.height),
+        "n_beyond_window": beyond,
+        "n_boot": args.n_boot,
+        "seed": args.seed,
+        "cells": cells,
+    }
+    args.output_json.write_text(json.dumps(out, indent=2))
+    logger.info("wrote %s (%d cells)", args.output_json, len(cells))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/test_long_history_compare.py
+++ b/tests/scripts/test_long_history_compare.py
@@ -1,0 +1,79 @@
+"""Long-history comparison: history tags, dump joins, stratified paired AUROC."""
+
+from datetime import datetime, timedelta
+
+import numpy as np
+import polars as pl
+
+from scripts.long_history_compare import (
+    compare,
+    history_lengths,
+    join_dumps,
+    tag_history,
+)
+
+
+def _events() -> pl.DataFrame:
+    t0 = datetime(2020, 1, 1)
+    rows = []
+    # subject 1: 6 timed events at hours 0..5 (+ a birth row with null time)
+    rows.append({"subject_id": 1, "time": None, "code": "MEDS_BIRTH"})
+    rows += [
+        {"subject_id": 1, "time": t0 + timedelta(hours=h), "code": f"LAB//{h}"}
+        for h in range(6)
+    ]
+    # subject 2: 3 events at hours 0, 2, 10
+    rows += [
+        {"subject_id": 2, "time": t0 + timedelta(hours=h), "code": "VITALS//x"}
+        for h in (0, 2, 10)
+    ]
+    return pl.DataFrame(rows)
+
+
+def test_history_lengths_count_timed_events_since_the_origin() -> None:
+    lengths = history_lengths(_events())
+    assert lengths[1].tolist() == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+    assert lengths[2].tolist() == [0.0, 2.0, 10.0]
+    frame = pl.DataFrame(
+        {"subject_id": [1, 1, 2, 2, 3], "time_hours": [0.5, 4.0, 1.0, 10.0, 3.0]}
+    )
+    tagged = tag_history(frame, lengths)
+    # events with time <= landmark: subj 1 @0.5 -> 1, @4.0 -> 5; subj 2 @1.0 -> 1,
+    # @10 -> 3; an unseen subject counts 0.
+    assert tagged["history_len"].to_list() == [1, 5, 1, 3, 0]
+
+
+def _dump(prefix_scores: float, n: int = 400, seed: int = 0) -> pl.DataFrame:
+    rng = np.random.default_rng(seed)
+    subjects = rng.integers(0, 40, size=n)
+    y = rng.integers(0, 2, size=n).astype(float)
+    return pl.DataFrame(
+        {
+            "subject_id": subjects.astype(float),
+            "visit_id": subjects.astype(float),
+            "time_hours": np.arange(n, dtype=float),
+            "event": ["death"] * n,
+            "y@24h": y,
+            "hazard@24h": prefix_scores * y + rng.normal(scale=0.5, size=n),
+            "gbm@24h": rng.normal(size=n),
+        }
+    )
+
+
+def test_join_and_compare_split_by_history_and_report_paired_delta() -> None:
+    a = _dump(2.0)  # strong scorer
+    b = _dump(0.2)  # weak scorer, same rows and labels (same seed)
+    joined = join_dumps(a, b, "hybrid", "transformer")
+    assert joined.height == a.height
+    assert set(joined.columns) >= {"y@24h", "hybrid@24h", "transformer@24h"}
+    # half the rows "beyond the window": first 200 landmarks short history, rest long
+    joined = joined.with_columns(pl.Series("history_len", [10] * 200 + [5000] * 200))
+    cells = compare(
+        joined, label_a="hybrid", label_b="transformer", window=2048, n_boot=50, seed=0
+    )
+    strata = {c["stratum"]: c for c in cells}
+    assert set(strata) == {"within_window", "beyond_window"}
+    for c in cells:
+        assert c["auroc_hybrid"] > c["auroc_transformer"]
+        assert c["delta_a_minus_b"]["point_estimate"] > 0
+        assert c["n_rows"] == 200

--- a/tests/scripts/test_long_history_compare.py
+++ b/tests/scripts/test_long_history_compare.py
@@ -1,46 +1,24 @@
-"""Long-history comparison: history tags, dump joins, stratified paired AUROC."""
-
-from datetime import datetime, timedelta
+"""Long-history comparison: truncation tags, dump joins, stratified paired AUROC."""
 
 import numpy as np
 import polars as pl
 
-from scripts.long_history_compare import (
-    compare,
-    history_lengths,
-    join_dumps,
-    tag_history,
-)
+from scripts.long_history_compare import compare, join_dumps, tag_truncation
 
 
-def _events() -> pl.DataFrame:
-    t0 = datetime(2020, 1, 1)
-    rows = []
-    # subject 1: 6 timed events at hours 0..5 (+ a birth row with null time)
-    rows.append({"subject_id": 1, "time": None, "code": "MEDS_BIRTH"})
-    rows += [
-        {"subject_id": 1, "time": t0 + timedelta(hours=h), "code": f"LAB//{h}"}
-        for h in range(6)
-    ]
-    # subject 2: 3 events at hours 0, 2, 10
-    rows += [
-        {"subject_id": 2, "time": t0 + timedelta(hours=h), "code": "VITALS//x"}
-        for h in (0, 2, 10)
-    ]
-    return pl.DataFrame(rows)
-
-
-def test_history_lengths_count_timed_events_since_the_origin() -> None:
-    lengths = history_lengths(_events())
-    assert lengths[1].tolist() == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
-    assert lengths[2].tolist() == [0.0, 2.0, 10.0]
-    frame = pl.DataFrame(
-        {"subject_id": [1, 1, 2, 2, 3], "time_hours": [0.5, 4.0, 1.0, 10.0, 3.0]}
+def test_tag_truncation_marks_subjects_whose_second_dump_starts_later() -> None:
+    a = pl.DataFrame(
+        {
+            "subject_id": [1.0, 1.0, 2.0, 2.0, 3.0],
+            "time_hours": [0.0, 4.0, 0.0, 8.0, 4.0],
+        }
     )
-    tagged = tag_history(frame, lengths)
-    # events with time <= landmark: subj 1 @0.5 -> 1, @4.0 -> 5; subj 2 @1.0 -> 1,
-    # @10 -> 3; an unseen subject counts 0.
-    assert tagged["history_len"].to_list() == [1, 5, 1, 3, 0]
+    b = pl.DataFrame(
+        {"subject_id": [1.0, 2.0, 2.0, 3.0], "time_hours": [4.0, 0.0, 8.0, 4.0]}
+    )
+    tags = tag_truncation(a, b).sort("subject_id")
+    assert tags["subject_id"].to_list() == [1.0, 2.0, 3.0]
+    assert tags["truncated"].to_list() == [True, False, False]
 
 
 def _dump(prefix_scores: float, n: int = 400, seed: int = 0) -> pl.DataFrame:
@@ -66,13 +44,11 @@ def test_join_and_compare_split_by_history_and_report_paired_delta() -> None:
     joined = join_dumps(a, b, "hybrid", "transformer")
     assert joined.height == a.height
     assert set(joined.columns) >= {"y@24h", "hybrid@24h", "transformer@24h"}
-    # half the rows "beyond the window": first 200 landmarks short history, rest long
-    joined = joined.with_columns(pl.Series("history_len", [10] * 200 + [5000] * 200))
-    cells = compare(
-        joined, label_a="hybrid", label_b="transformer", window=2048, n_boot=50, seed=0
-    )
+    # half the rows from subjects the transformer saw whole, half truncated
+    joined = joined.with_columns(pl.Series("truncated", [False] * 200 + [True] * 200))
+    cells = compare(joined, label_a="hybrid", label_b="transformer", n_boot=50, seed=0)
     strata = {c["stratum"]: c for c in cells}
-    assert set(strata) == {"within_window", "beyond_window"}
+    assert set(strata) == {"whole", "truncated"}
     for c in cells:
         assert c["auroc_hybrid"] > c["auroc_transformer"]
         assert c["delta_a_minus_b"]["point_estimate"] > 0


### PR DESCRIPTION
## Why

Amrit: the paper keeps the hybrid backbone for its streaming property (any record length at constant memory per step) and reports the transformer as the portability check, claiming no superiority either way. This substantiates the architectural point instead of asserting it.

## What

`scripts/long_history_compare.py`: joins two alert dumps on (subject, visit, time, event); tags each subject from the dumps themselves as `truncated` (the transformer's first scored row comes later than the hybrid's, so its packed-context window never saw the record's start) or `whole`; per (event, horizon) and stratum reports both models' hazard AUROC with a paired subject-clustered bootstrap of the difference. Tests cover the tagging, the join, and the stratified comparison on synthetic dumps.

## What it found (MIMIC-IV, full_run_DEC_v12 vs full_run_DEC_v12_tfm, all 37 held-out shards)

On the 15,089 subjects the transformer saw whole, death, ICU admission and vasopressor AUROCs are tied (every interval covers zero) and the transformer leads AKI and Sepsis-3 by about 0.02. On the 7,227 truncated subjects the transformer leads death by 0.035 (0.985 vs 0.950), but every row of that stratum lies within 2048 tokens of the record's end and the model was trained with the same end-anchored truncation, so it can read time-to-end from its window position; that stratum is not a clean backbone comparison (the docstring says so). The streaming advantage the hybrid was chosen for is not demonstrated by this data; a landmark-anchored sliding window at evaluation (and random-offset windows in training) is the fix.

CPU only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KocCJujRUmyVvuoh5ushFU