### PR TITLE
GEMINI exports: whitelist at_risk_restricted, stratify_by and n_positive_gaps

### DIFF
--- a/scripts/gemini/run.sh
+++ b/scripts/gemini/run.sh
@@ -1203,8 +1203,8 @@ OBSERVABILITY_METRICS_KEYS = {
     "name", "n_subjects", "observed_rate", "auroc", "accuracy_at_0_5",
 }
 TIME_METRICS_KEYS = {
-    "nll", "n_positions", "same_instant_accuracy", "same_instant_rate",
-    "calibration", "calibration_after_bundle",
+    "nll", "n_positions", "n_positive_gaps", "same_instant_accuracy",
+    "same_instant_rate", "calibration", "calibration_after_bundle",
 }
 CALIBRATION_ENTRY_KEYS = {"predicted", "observed"}
 TOP_LEVEL_KEYS = {
@@ -1834,7 +1834,7 @@ PY
         echo "$STEP complete. Results at $OUTPUT_JSON"
         _export_aggregate_json \
             "scripts/gemini/out/evals/${run_name}_steering_full.json" "$OUTPUT_JSON" \
-            "site layer_index tau suppress_strength horizons_hours event_names gammas lifted_tokens summaries" \
+            "site layer_index tau suppress_strength horizons_hours event_names gammas lifted_tokens summaries at_risk_restricted stratify_by" \
             || echo "WARNING: steering output not exported (see above)." >&2
     }
 


### PR DESCRIPTION
## Why

On the GEMINI node, `run.sh steering` and the eval-forecast backfill refused to export `gemini_full_DEC_v12`'s outputs: the steering summary now carries `at_risk_restricted` and `stratify_by`, and `TimeMetrics` carries `n_positive_gaps`, none of which the export whitelists knew. The files were exported by hand with corrected key sets (provenance on the gemini remote at a93ce24); this PR makes the script agree.

## What

- steering export allowed keys: + `at_risk_restricted stratify_by`
- `TIME_METRICS_KEYS`: + `n_positive_gaps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KocCJujRUmyVvuoh5ushFU