### PR TITLE
Sliding windows in training too, and every position a target exactly once

### DIFF
--- a/odyssey/data/packed_context.py
+++ b/odyssey/data/packed_context.py
@@ -107,17 +107,24 @@ class _RowBuilder:
     values: list[float] = field(default_factory=list)
     static: list[bool] = field(default_factory=list)
     score: list[bool] = field(default_factory=list)
+    target_ok: list[bool] = field(default_factory=list)
 
     def __len__(self) -> int:
         """Return the number of tokens packed into this row so far."""
         return len(self.concept_ids)
 
-    def append_patient(self, seq: PatientSequence, *, score_from: int = 0) -> None:
+    def append_patient(
+        self, seq: PatientSequence, *, score_from: int = 0, target_from: int = 0
+    ) -> None:
         """Append one (whole, truncated, or windowed) patient's tokens, as-is.
 
         ``score_from`` marks where scoring may start inside this segment:
         positions before it are context that an earlier overlapping
         window already scored (sliding-window mode); 0 scores everything.
+        ``target_from`` is the same boundary for next-token targets, one
+        position earlier for a non-first window, because a window's last
+        position never has an in-window target and the window before
+        stopped one short of it.
 
         No timestamp adjustment: ``time_stamps`` are each patient's own
         raw values, unchanged. The module docstring explains why that is
@@ -153,6 +160,7 @@ class _RowBuilder:
         patient_end[-1] = True
         self.patient_end.extend(patient_end)
         self.score.extend([i >= score_from for i in range(n)])
+        self.target_ok.extend([i >= target_from for i in range(n)])
 
     def pad_to(self, capacity: int) -> "_Row":
         """Return this row's content, right-padded to exactly ``capacity`` tokens."""
@@ -175,6 +183,7 @@ class _RowBuilder:
             values=self.values + [_NAN] * pad,
             static=self.static + [False] * pad,
             score=self.score + [False] * pad,
+            target_ok=self.target_ok + [False] * pad,
             n_real=n,
         )
 
@@ -197,6 +206,7 @@ class _Row:
     values: list[float]
     static: list[bool]
     score: list[bool]
+    target_ok: list[bool]
     n_real: int
 
 
@@ -246,8 +256,8 @@ class PackedContextSampler:
         self.batch_size = batch_size
         self.max_context = max_context
         self.window_stride = window_stride
-        self._held: tuple[PatientSequence, int] | None = None
-        self._pending: list[tuple[PatientSequence, int]] = []
+        self._held: tuple[PatientSequence, int, int] | None = None
+        self._pending: list[tuple[PatientSequence, int, int]] = []
         self._exhausted = False
         self.truncated_subject_ids: list[int] = []
         self.truncation_boundaries: dict[int, float] = {}
@@ -260,24 +270,34 @@ class PackedContextSampler:
         needs to know which landmarks a truncated subject legitimately
         lost."""
 
-    def _windows(self, patient: PatientSequence) -> list[tuple[PatientSequence, int]]:
-        """Split a too-long patient into overlapping windows with score offsets."""
+    def _windows(
+        self, patient: PatientSequence
+    ) -> list[tuple[PatientSequence, int, int]]:
+        """Split a too-long patient into overlapping windows.
+
+        Returns ``(window, score_from, target_from)`` triples: positions
+        from ``score_from`` are scored by this window, positions from
+        ``target_from`` carry its next-token targets (one earlier than
+        ``score_from`` for every window after the first, since a window's
+        last position has no in-window target).
+        """
         assert self.window_stride is not None
         n, width, stride = len(patient), self.max_context, self.window_stride
-        out: list[tuple[PatientSequence, int]] = []
+        out: list[tuple[PatientSequence, int, int]] = []
         scored_to = 0
         start = 0
         while True:
-            end = min(start + width, n)
-            if end == n:
+            if start + width >= n:
                 start = max(0, n - width)
-            out.append((patient.window(start, start + width), scored_to - start))
+            score_from = scored_to - start
+            target_from = max(0, scored_to - 1) - start if scored_to else 0
+            out.append((patient.window(start, start + width), score_from, target_from))
             scored_to = min(start + width, n)
             if scored_to >= n:
                 return out
             start += stride
 
-    def _next_patient(self) -> tuple[PatientSequence, int] | None:
+    def _next_patient(self) -> tuple[PatientSequence, int, int] | None:
         if self._held is not None:
             held = self._held
             self._held = None
@@ -300,7 +320,7 @@ class PackedContextSampler:
                 -self.max_context
             ]
             patient = _truncate_head(patient, self.max_context)
-        return (patient, 0)
+        return (patient, 0, 0)
 
     def next_chunk(self) -> StreamingChunk | None:
         """Pack up to ``batch_size`` rows, each up to ``max_context`` tokens.
@@ -318,9 +338,11 @@ class PackedContextSampler:
                 item = self._next_patient()
                 if item is None:
                     break
-                patient, score_from = item
+                patient, score_from, target_from = item
                 if len(row) == 0 or len(row) + len(patient) <= self.max_context:
-                    row.append_patient(patient, score_from=score_from)
+                    row.append_patient(
+                        patient, score_from=score_from, target_from=target_from
+                    )
                 else:
                     self._held = item
                     break
@@ -360,6 +382,7 @@ class PackedContextSampler:
         values_full = _stack("values", torch.float)
         static_full = _stack("static", torch.bool)
         score_full = _stack("score", torch.bool)
+        target_ok_full = _stack("target_ok", torch.bool)
 
         # Same-window shift by one (not the +1-lookahead-token convention
         # PackedLaneSampler uses): max_context means exactly the window
@@ -371,6 +394,10 @@ class PackedContextSampler:
         not_target[:, -1] = True
         targets = targets.masked_fill(not_target, PAD_ID)
         real_mask = (subject_ids_full != NO_SUBJECT) & ~not_target
+        if self.window_stride is not None:
+            # sliding windows: a window's leading positions are context only
+            # (the window before already trained/scored them), never targets
+            real_mask = real_mask & target_ok_full
 
         batch = ClinicalSequenceBatch(
             concept_ids=concept_ids_full,

--- a/odyssey/inference/alerts.py
+++ b/odyssey/inference/alerts.py
@@ -2734,6 +2734,9 @@ def evaluate_alerts(  # noqa: PLR0912, PLR0915
         logger.info(
             "[alerts] collecting model scores at %.0fh landmarks", landmark_hours
         )
+    if window_stride is None:
+        # the run's own training-time choice, saved with its config
+        window_stride = getattr(config, "window_stride", None)
     truncation_boundaries: dict[int, float] = {}
     unscoreable_keys: set[tuple[int, int, float]] = set()
     if degraded_shard_dir is not None:

--- a/odyssey/inference/run_inference.py
+++ b/odyssey/inference/run_inference.py
@@ -851,6 +851,7 @@ def _build_sampler(
     num_lanes: int,
     chunk_size: int,
     max_context: int,
+    window_stride: int | None = None,
 ) -> PackedLaneSampler | PackedContextSampler:
     """Dispatch on ``backbone``, matching :func:`odyssey.training.train.build_model`.
 
@@ -861,7 +862,10 @@ def _build_sampler(
     """
     if backbone == "transformer":
         return PackedContextSampler(
-            patients, batch_size=num_lanes, max_context=max_context
+            patients,
+            batch_size=num_lanes,
+            max_context=max_context,
+            window_stride=window_stride,
         )
     return PackedLaneSampler(
         patients, num_lanes=num_lanes, chunk_size=chunk_size, reset_prob=0.0
@@ -883,6 +887,7 @@ def run_streaming_inference(
     concepts: Sequence[AnyConceptDefinition] | None = None,
     backbone: str = "hybrid",
     max_context: int = 4096,
+    window_stride: int | None = None,
     source: str = "mimic_iv",
 ) -> InferenceResults:
     """Stream held-out patients through ``model`` and score every eval question.
@@ -917,6 +922,7 @@ def run_streaming_inference(
         num_lanes=num_lanes,
         chunk_size=chunk_size,
         max_context=max_context,
+        window_stride=window_stride,
     )
 
     time_head = getattr(model, "time_head", None)
@@ -1161,6 +1167,7 @@ def evaluate_run(
         concepts=concepts,
         backbone=getattr(config, "backbone", "hybrid"),
         max_context=getattr(config, "max_context", 4096),
+        window_stride=getattr(config, "window_stride", None),
         source=source,
     )
 

--- a/odyssey/training/train.py
+++ b/odyssey/training/train.py
@@ -163,6 +163,15 @@ class TrainingConfig:
     """Token budget per packed row for backbone="transformer" (see
     PackedContextSampler). Unused by the hybrid backbone."""
 
+    window_stride: int | None = None
+    """backbone="transformer" only: score and train too-long records with
+    sliding ``max_context`` windows every this many tokens instead of
+    keeping each record's last ``max_context`` tokens (see
+    PackedContextSampler). Each position is then a target exactly once,
+    with at least ``max_context - window_stride`` tokens of context, and
+    no window is anchored to the record's end. None keeps the tail
+    truncation. Saved with the run and honoured by every evaluation."""
+
     # Backbone (EHRHybridBackbone). Defaults are modest, not the paper-scale
     # numbers -- see the training run's own README note on why.
     hidden_size: int = 256
@@ -1550,7 +1559,10 @@ def _run_training(  # noqa: PLR0912, PLR0915
         patients = corpus.make_train_patients(epoch)
         if config.backbone == "transformer":
             return PackedContextSampler(
-                patients, batch_size=config.num_lanes, max_context=config.max_context
+                patients,
+                batch_size=config.num_lanes,
+                max_context=config.max_context,
+                window_stride=config.window_stride,
             )
         return PackedLaneSampler(
             patients,
@@ -1568,7 +1580,10 @@ def _run_training(  # noqa: PLR0912, PLR0915
         )
         if config.backbone == "transformer":
             return PackedContextSampler(
-                patients, batch_size=config.num_lanes, max_context=config.max_context
+                patients,
+                batch_size=config.num_lanes,
+                max_context=config.max_context,
+                window_stride=config.window_stride,
             )
         return PackedLaneSampler(
             patients, num_lanes=config.num_lanes, chunk_size=config.chunk_size

--- a/tests/odyssey/data/test_packed_context.py
+++ b/tests/odyssey/data/test_packed_context.py
@@ -491,3 +491,16 @@ def test_window_stride_must_fit_the_window() -> None:
         PackedContextSampler(
             _patients([]), batch_size=1, max_context=4, window_stride=5
         )
+
+
+def test_window_stride_makes_context_only_positions_non_targets() -> None:
+    sampler = PackedContextSampler(
+        _patients([_seq(1, 7)]), batch_size=1, max_context=4, window_stride=2
+    )
+    chunks = list(sampler)
+    targets_seen: list[int] = []
+    for chunk in chunks:
+        assert chunk.score_mask is not None
+        targets_seen.extend(chunk.targets[chunk.real_mask].tolist())
+    # every token except the record's first is predicted exactly once
+    assert sorted(targets_seen) == [1001 + i for i in range(6)]


### PR DESCRIPTION
The second commit of the sliding-window work (94d394b on feat/sliding-window-eval) was written after #236 was merged, so main has the evaluation side only. This PR carries it, rebased onto main, unchanged.

TrainingConfig.window_stride plumbs the sliding-window sampler into training and tuning; run_inference and alerts read it from the run's saved config so a model trained this way is evaluated this way. A window's last position never has an in-window target, so a later window's targets start one position before its scored range: every token of a long record is predicted exactly once per epoch and every scored position is scored exactly once, with no window anchored to the record's end.

Needed by the landmark-anchored transformer retrain (full_run_DEC_v12_tfm_slide), which failed at startup on main with `TrainingConfig.__init__() got an unexpected keyword argument 'window_stride'`. The retrain is running from this branch's checkout on the MIMIC card.

Tests: `tests/odyssey/data/test_packed_context.py` and `tests/odyssey/training` pass; ruff, format and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KocCJujRUmyVvuoh5ushFU