### PR TITLE
Pin the renamed GEMINI run directory

### DIFF
--- a/odyssey/inference/legacy_concept_pins.py
+++ b/odyssey/inference/legacy_concept_pins.py
@@ -34,6 +34,28 @@ LEGACY_CONCEPT_PINS: dict[str, tuple[str, ...]] = {
     # haematology concepts plus hypoxemic_respiratory_failure, oliguria,
     # sepsis3 and shock gained GEMINI code mappings afterwards, taking
     # today's registry to 25. Recovered at training commit c1dadb9.
+    # gemini_full_v10_15c is the same checkpoint under the name it was moved
+    # to when a 25-concept retrain was attempted against the original path.
+    # Pins key on the directory name, so a renamed run silently loses its
+    # pin and refuses to load; alias rather than rename the canonical entry,
+    # since either directory may hold the checkpoint on a given node.
+    "gemini_full_v10_15c": (
+        "tachycardia",
+        "bradycardia",
+        "hypotension",
+        "hypertension",
+        "hypoxia",
+        "fever",
+        "hypothermia",
+        "elevated_lactate",
+        "sustained_tachypnea",
+        "acute_kidney_injury",
+        "aki_stage_2",
+        "aki_stage_3",
+        "sirs",
+        "qsofa",
+        "on_vasopressors",
+    ),
     "gemini_full_v10": (
         "tachycardia",
         "bradycardia",

--- a/tests/odyssey/inference/test_legacy_concept_pins.py
+++ b/tests/odyssey/inference/test_legacy_concept_pins.py
@@ -28,6 +28,15 @@ def test_pin_lookup_ignores_path_and_trailing_slash() -> None:
     assert pinned_concept_names("runs/never_trained") is None
 
 
+def test_a_renamed_run_directory_keeps_its_pin() -> None:
+    # Pins key on the directory name, so moving a run aside (as happens when
+    # a retrain is attempted against the original path) would otherwise drop
+    # the pin and make the checkpoint refuse to load.
+    assert pinned_concept_names("gemini_full_v10_15c") == pinned_concept_names(
+        "gemini_full_v10"
+    )
+
+
 def test_pinned_lists_match_the_widths_they_were_recovered_from() -> None:
     # The pins exist to match a frozen bottleneck width. GEMINI trained with
     # 15 concepts and eICU-CRD with 26; if either list is edited to a


### PR DESCRIPTION
`gemini_full_v10` was moved aside to `gemini_full_v10_15c` on the GEMINI node
when a 25-concept retrain was attempted against the original path. The retrain
was preempted before writing a checkpoint, so `_15c` now holds the only
checkpoint and `gemini_full_v10` is an empty directory.

Pins key on the directory basename, so that move silently dropped the pin and
`load_run` would refuse the very checkpoint the pin was written for. Aliased
rather than renamed, since either directory may hold the checkpoint depending
on the node.

Unblocks `eval-forecast`, `interventions` and `alerts` against that checkpoint.

Note: `integration-tests` currently fails repo-wide on an expired PhysioNet TLS
certificate (`certificate has expired` on physionet.org), which breaks the MEDS
demo download inside `MEDS_extract`. Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrTsvHtaCn7DiMhkFUfL2b