### PR TITLE
Use the run's own concept set in every caller, not just load_run

### DIFF
--- a/odyssey/inference/interventions.py
+++ b/odyssey/inference/interventions.py
@@ -82,7 +82,6 @@ import torch
 import torch.nn.functional as F  # noqa: N812
 
 from odyssey.data.code_normalization import maybe_normalize
-from odyssey.data.concepts import concepts_for_source
 from odyssey.data.history_recap import maybe_history_recap
 from odyssey.data.sidecars import activate_sidecars
 from odyssey.data.streaming import NO_SUBJECT, PackedLaneSampler, StreamingChunk
@@ -92,6 +91,7 @@ from odyssey.inference.concept_attribution import (
     calibrated_gammas,
     mean_concept_directions,
 )
+from odyssey.inference.legacy_concept_pins import resolve_concepts_for_run
 from odyssey.inference.run_inference import (
     _CODE_TYPE_NAMES,
     _build_type_lookup,
@@ -543,7 +543,12 @@ def evaluate_interventions(
     )
     source = getattr(config, "source", "mimic_iv")
     activate_sidecars(held_out_shard_dir)
-    concepts = concepts_for_source(source, task_set=getattr(config, "task_set", "v1"))
+    # The run's own concept set, not today's: a checkpoint trained against
+    # an older registry has fewer bottleneck slots than concepts_for_source
+    # now returns, and the two are zipped together below.
+    concepts = resolve_concepts_for_run(
+        str(run_dir), source, getattr(config, "task_set", "v1")
+    )
     events_binned = add_value_tokens(raw_events, binner, source=source)
 
     supervision: ConceptSupervision = getattr(config, "concept_supervision", "stay")

--- a/odyssey/inference/legacy_concept_pins.py
+++ b/odyssey/inference/legacy_concept_pins.py
@@ -25,6 +25,13 @@ printed rather than sorting it.
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from odyssey.data.concepts import canonical_concept_name, concepts_for_source
+
+
+if TYPE_CHECKING:
+    from odyssey.data.concepts import AnyConceptDefinition
 
 
 # run directory basename -> the concept names that run trained with, in slot
@@ -154,3 +161,44 @@ def check_concept_count(
         "(its env_fingerprint.json records the training commit); loading it "
         "against today's registry would build a model of the wrong width."
     )
+
+
+def resolve_concepts_for_run(
+    run_dir: str, source: str, task_set: str
+) -> list[AnyConceptDefinition]:
+    """Return the concept DEFINITIONS a run trained with, in its own slot order.
+
+    :func:`pinned_concept_names` gives names; callers that build concept
+    labels need the definitions behind them. Pinning only ``load_run`` is not
+    enough: every caller that separately calls ``concepts_for_source`` gets
+    today's larger list and then mismatches the model it was just handed. That
+    is a real failure, not a hypothetical one -- it surfaced as
+    ``zip() argument 2 is shorter than argument 1`` in interventions.py, where
+    25 registry concepts met a 15-slot bottleneck's calibration gammas.
+
+    Pinned names are resolved through :func:`canonical_concept_name`, since a
+    pin records the name a checkpoint trained under and concepts get renamed
+    (``shock`` is today's ``sustained_hypotension_map``).
+    """
+    definitions = {c.name: c for c in concepts_for_source(source, task_set=task_set)}
+    pinned = pinned_concept_names(run_dir)
+    if pinned is None:
+        return list(definitions.values())
+    resolved: list[AnyConceptDefinition] = []
+    missing: list[str] = []
+    for name in pinned:
+        definition = definitions.get(name) or definitions.get(
+            canonical_concept_name(name)
+        )
+        if definition is None:
+            missing.append(name)
+        else:
+            resolved.append(definition)
+    if missing:
+        raise ValueError(
+            f"{run_dir}: pinned concepts {missing} do not resolve for source "
+            f"{source!r} under task_set {task_set!r}. The pin records what the "
+            "checkpoint trained with; if the registry no longer defines those "
+            "concepts the pin cannot be honoured."
+        )
+    return resolved

--- a/tests/odyssey/inference/test_legacy_concept_pins.py
+++ b/tests/odyssey/inference/test_legacy_concept_pins.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import pytest
 import torch
 
+from odyssey.data.concepts import concepts_for_source
 from odyssey.inference.legacy_concept_pins import (
     LEGACY_CONCEPT_PINS,
     check_concept_count,
     checkpoint_num_concepts,
     pinned_concept_names,
+    resolve_concepts_for_run,
 )
 
 
@@ -73,3 +75,24 @@ def test_check_refuses_with_both_counts_named() -> None:
 
 def test_check_is_silent_for_a_model_with_no_bottleneck() -> None:
     check_concept_count("runs/baseline", {}, ["c"] * 25)
+
+
+def test_resolve_concepts_returns_the_runs_own_set_in_slot_order() -> None:
+    # The GEMINI checkpoint trained with 15 of the 25 its source resolves
+    # today. A caller that rebuilt the list from the registry would hand a
+    # 25-long list to a 15-slot bottleneck.
+    got = resolve_concepts_for_run("runs/gemini_full_v10", "gemini", "v3")
+    assert [c.name for c in got] == list(LEGACY_CONCEPT_PINS["gemini_full_v10"])
+
+
+def test_resolve_concepts_follows_a_rename() -> None:
+    # eICU's pin records "shock", which the registry now calls
+    # sustained_hypotension_map; the pin must still resolve.
+    got = resolve_concepts_for_run("runs/eicu_full_v10", "eicu", "v3")
+    assert len(got) == len(LEGACY_CONCEPT_PINS["eicu_full_v10"])
+    assert "sustained_hypotension_map" in {c.name for c in got}
+
+
+def test_resolve_concepts_is_the_full_registry_when_unpinned() -> None:
+    got = resolve_concepts_for_run("runs/not_pinned", "mimic_iv", "v3")
+    assert len(got) == len(concepts_for_source("mimic_iv", task_set="v3"))


### PR DESCRIPTION
Pinning `load_run` fixed model construction but not the callers that separately
call `concepts_for_source` and then zip the result against something derived
from the model.

`interventions.py` did exactly that and failed on GEMINI:

```
ValueError: zip() argument 2 is shorter than argument 1
  for c, g in zip(concepts, calibration_gammas.tolist(), strict=True)
```

25 registry concepts meeting a 15-slot bottleneck's calibration gammas. This
blocks the Q2/Q3 intervention results on GEMINI.

`resolve_concepts_for_run` returns the concept **definitions** a run trained
with, in its own slot order, since callers that build concept labels need
definitions rather than names. Pinned names resolve through
`canonical_concept_name`, because a pin records the name a checkpoint trained
under and concepts get renamed (eICU's pin says `shock`, which the registry now
calls `sustained_hypotension_map`) — covered by a test.

Unpinned runs are unaffected: they get today's registry exactly as before.

Note: `integration-tests` fails repo-wide on an expired PhysioNet TLS
certificate, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrTsvHtaCn7DiMhkFUfL2b